### PR TITLE
Create redbug escript

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,16 @@
 REBAR = rebar3
 
-.PHONY: all compile test clean
+.PHONY: all compile escriptize test clean
 .PHONY: test eunit xref dialyze
 .PHONY: release release_minor release_major release_patch
 
-all: compile
+all: compile escriptize
 
 compile:
 	@$(REBAR) compile
+
+escriptize:
+	@$(REBAR) escriptize
 
 clean:
 	@find . -name "*~" -exec rm {} \;

--- a/rebar.config
+++ b/rebar.config
@@ -4,3 +4,5 @@
 {xref_checks,         [undefined_function_calls]}.
 {cover_enabled,       true}.
 {cover_print_enabled, true}.
+
+{escript_emu_args,    "%%! -hidden\n"}.


### PR DESCRIPTION
Use rebar3's "escriptize" command to create an escript archive file
containing the entire redbug application.  Add redbug:main/1 to handle
command line arguments and start tracing when invoked as an escript.
