### PR TITLE
support # syntax for records

### DIFF
--- a/src/redbug.app.src
+++ b/src/redbug.app.src
@@ -1,6 +1,6 @@
 {application, redbug,
  [{description, "Erlang Tracing Debugger"},
-  {vsn, "1.2.1-0"},
+  {vsn, "1.2.1.0"},
   {registered, []},
   {applications,
    [kernel,

--- a/src/redbug.app.src
+++ b/src/redbug.app.src
@@ -1,6 +1,6 @@
 {application, redbug,
  [{description, "Erlang Tracing Debugger"},
-  {vsn, "1.2.1"},
+  {vsn, "1.2.1-0"},
   {registered, []},
   {applications,
    [kernel,

--- a/src/redbug_msc.erl
+++ b/src/redbug_msc.erl
@@ -11,6 +11,14 @@
 
 -export([transform/1]).
 
+-define(LEX_COMMA,        {',',1}).
+-define(LEX_COLUMN,       {':',1}).
+-define(LEX_HASH,         {'#',1}).
+-define(LEX_EQUAL,        {'=',1}).
+-define(LEX_OPEN_BRACE,   {'{',1}).
+-define(LEX_CLOSE_BRACE,  {'}',1}).
+-define(LEX_ANY,          {var,1,'_'}).
+
 transform(E) ->
   try
     compile(parse(to_string(E)))
@@ -195,7 +203,13 @@ split(Str) ->
 %% parse body
 body(Str) ->
   case erl_scan:tokens([],Str++". ",1) of
-    {done,{ok,Toks,1},[]} ->
+    {done,{ok,Toks0,1},[]} ->
+      Toks = case Toks0 of
+        [{atom,1,Module},?LEX_COLUMN | _] ->
+          Defs = scan_records(read_records(Module, []), []),
+          replace_records(Defs, Toks0);
+        _ -> Toks0
+      end,
       case erl_parse:parse_exprs(Toks) of
         {ok,[{op,_,'/',{remote,_,{atom,_,M},{atom,_,F}},{integer,_,Ari}}]} ->
           {M,F,lists:duplicate(Ari,{var,'_'})}; % m:f/2
@@ -286,3 +300,362 @@ eval_bin(Bin) ->
   catch
     _:R -> throw({bad_binary,R})
   end.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% replace #records by tuples
+replace_records(Defs, Toks) ->
+  lists:reverse(rewrite_records(parse_records(Defs, Toks, []), [])).
+
+%%% replace #records with a private tuple {record, {name, fields, values}} in the list of tokens
+
+parse_records(_Defs, [], Toks) -> lists:reverse(Toks);
+
+parse_records(Defs, [?LEX_HASH,{atom,1,RecordName},?LEX_OPEN_BRACE | T], Toks) ->
+  case lists:keyfind(RecordName, 1, Defs) of
+    {_Name, Fields} ->
+      {Rec, Remainder} = parse_record(Defs, RecordName, Fields, T),
+      parse_records(Defs, Remainder, [Rec | Toks]);
+    _ ->
+      throw({missing_record, RecordName})
+  end;
+
+parse_records(Defs, [H | T], Toks) ->
+  parse_records(Defs, T, [H | Toks]).
+
+parse_record(Defs, RecordName, Fields, T) ->
+  {Values, Remainder} = parse_record_fields([], 0, T),
+  Values1 = lists:map(fun({Name, Value}) -> {Name, parse_records(Defs, Value, [])} end, Values),
+  {{record, {RecordName, Fields, Values1}}, Remainder}.
+
+parse_record_fields(Values, 0, [{atom,1,Field},?LEX_EQUAL | T]) ->
+  parse_record_value(Values, 0, Field, [], T);
+
+parse_record_fields(Values, 0, [?LEX_CLOSE_BRACE | T]) -> {Values, T}.
+
+parse_record_value(Values, 0, Field, Value, [?LEX_COMMA | T]) ->
+  parse_record_fields([{Field, lists:reverse(Value)} | Values], 0, T);
+
+parse_record_value(Values, 0, Field, Value, [?LEX_CLOSE_BRACE | T]) ->
+  parse_record_fields([{Field, lists:reverse(Value)} | Values], 0, [?LEX_CLOSE_BRACE | T]);
+
+parse_record_value(Values, Depth, Field, Value, [?LEX_OPEN_BRACE | T]) ->
+  parse_record_value(Values, Depth + 1, Field, [?LEX_OPEN_BRACE | Value], T);
+
+parse_record_value(Values, Depth, Field, Value, [?LEX_CLOSE_BRACE | T]) ->
+  parse_record_value(Values, Depth - 1, Field, [?LEX_CLOSE_BRACE | Value], T);
+
+parse_record_value(Values, Depth, Field, Value, [H | T]) ->
+  parse_record_value(Values, Depth, Field, [H | Value], T).
+
+%%% replace the private tuple {record, {name, fields, values}} with record as tuples
+
+rewrite_records([{record, {Name, Fields, Values}} | T], L) ->
+  {_, NL} = lists:foldl(fun
+                          (Field, {Rank, Acc0}) ->
+                            Acc = [?LEX_COMMA | Acc0],
+                            case lists:keyfind(Field, 1, Values) of
+                              {_Name, Values0} ->
+                                {Rank + 1, rewrite_records(Values0, Acc)};
+                              _ ->
+                                {Rank + 1, [?LEX_ANY | Acc]}
+                            end
+                        end, {1, [{atom,1,Name},?LEX_OPEN_BRACE | L]}, Fields),
+  rewrite_records(T, [?LEX_CLOSE_BRACE | NL]);
+
+rewrite_records([], L) -> L;
+
+rewrite_records([E | T], L) ->
+  rewrite_records(T, [E | L]).
+
+%%% create a property list with all records (in abstract code)
+
+scan_records([], X) when not is_list(X) -> [];
+scan_records([], L) -> L;
+scan_records([{attribute,_,record, {Name, Fields}} | T], L) ->
+  scan_records(T, [scan_record(Name, Fields) | L]);
+
+scan_records([_H | T], L) ->
+  scan_records(T, L).
+
+scan_record(Name, Fields) ->
+  {Name, lists:reverse(scan_record_fields(Fields, []))}.
+
+scan_record_fields([], L) -> L;
+
+scan_record_fields([{typed_record_field, F, _T} | T], L) ->
+  scan_record_fields(T, scan_record_fields([F], L));
+
+scan_record_fields([Rec | T], L) when element(1, Rec) == record_field ->
+  {atom, _, N} = element(3, Rec),
+  scan_record_fields(T, [N | L]).
+
+%%% Read record information from file(s)  (source code from "stdlib/shell.erl")
+
+read_records(FileOrModule, Opts0) ->
+  Opts = lists:delete(report_warnings, Opts0),
+  case find_file(FileOrModule) of
+    {files,[File]} ->
+      read_file_records(File, Opts);
+    {files,Files} ->
+      lists:flatmap(fun(File) ->
+        case read_file_records(File, Opts) of
+          RAs when is_list(RAs) -> RAs;
+          _ -> []
+        end
+      end, Files);
+    Error ->
+      Error
+  end.
+
+-include_lib("kernel/include/file.hrl").
+
+find_file(Mod) when is_atom(Mod) ->
+  case code:which(Mod) of
+    File when is_list(File) ->
+      {files,[File]};
+    preloaded ->
+      {_M,_Bin,File} = code:get_object_code(Mod),
+      {files,[File]};
+    _Else -> % non_existing, interpreted, cover_compiled
+      {error,nofile}
+  end;
+find_file(File) ->
+  case catch filelib:wildcard(File) of
+    {'EXIT',_} ->
+      {error,invalid_filename};
+    Files ->
+      {files,Files}
+  end.
+
+read_file_records(File, Opts) ->
+  case filename:extension(File) of
+    ".beam" ->
+      case beam_lib:chunks(File, [abstract_code,"CInf"]) of
+        {ok,{_Mod,[{abstract_code,{Version,Forms}},{"CInf",CB}]}} ->
+          case record_attrs(Forms) of
+            [] when Version =:= raw_abstract_v1 ->
+              [];
+            [] ->
+              %% If the version is raw_X, then this test
+              %% is unnecessary.
+              try_source(File, CB);
+            Records ->
+              Records
+          end;
+        {ok,{_Mod,[{abstract_code,no_abstract_code},{"CInf",CB}]}} ->
+          try_source(File, CB);
+        Error ->
+          %% Could be that the "Abst" chunk is missing (pre R6).
+          Error
+      end;
+    _ ->
+      parse_file(File, Opts)
+  end.
+
+%% This is how the debugger searches for source files. See int.erl.
+try_source(Beam, CB) ->
+  Os = case lists:keyfind(options, 1, binary_to_term(CB)) of
+         false -> [];
+         {_, Os0} -> Os0
+       end,
+  Src0 = filename:rootname(Beam) ++ ".erl",
+  case is_file(Src0) of
+    true -> parse_file(Src0, Os);
+    false ->
+      EbinDir = filename:dirname(Beam),
+      Src = filename:join([filename:dirname(EbinDir), "src",
+        filename:basename(Src0)]),
+      case is_file(Src) of
+        true -> parse_file(Src, Os);
+        false -> {error, nofile}
+      end
+  end.
+
+is_file(Name) ->
+  case filelib:is_file(Name) of
+    true ->
+      not filelib:is_dir(Name);
+    false ->
+      false
+  end.
+
+parse_file(File, Opts) ->
+  Cwd = ".",
+  Dir = filename:dirname(File),
+  IncludePath = [Cwd,Dir|inc_paths(Opts)],
+  case epp:parse_file(File, IncludePath, pre_defs(Opts)) of
+    {ok,Forms} ->
+      record_attrs(Forms);
+    Error ->
+      Error
+  end.
+
+pre_defs([{d,M,V}|Opts]) ->
+  [{M,V}|pre_defs(Opts)];
+pre_defs([{d,M}|Opts]) ->
+  [M|pre_defs(Opts)];
+pre_defs([_|Opts]) ->
+  pre_defs(Opts);
+pre_defs([]) -> [].
+
+inc_paths(Opts) ->
+  [P || {i,P} <- Opts, is_list(P)].
+
+record_attrs(Forms) ->
+  [A || A = {attribute,_,record,_D} <- Forms].
+
+%%% End of reading record information from file(s)
+
+%%-------------------------------------------------------------------------
+%%              UNIT Tests
+%%-------------------------------------------------------------------------
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+scan(Str) ->
+  {done,{ok,Toks,1},[]} = erl_scan:tokens([], Str++". ",1), Toks.
+
+replace_records_test() ->
+
+  R1 = parse_records([
+      {myrecord, [firstname,age,now]},
+      {jid, [user,server,resource]}
+    ],
+    scan("#myrecord{now = #jid{server = <<\"r.com\">>}, firstname = <<\"Frank\">>, age = {over, 20}}"),
+    []
+  ),
+
+  ?assertEqual([
+      {record,
+        {
+          myrecord,
+          [firstname,age,now],
+          [
+            {age,[?LEX_OPEN_BRACE, {atom,1,over}, ?LEX_COMMA, {integer,1,20}, ?LEX_CLOSE_BRACE]},
+            {firstname,[{'<<',1},{string,1,"Frank"},{'>>',1}]},
+            {now,[{record, {
+                jid,
+                [user,server,resource],
+                [
+                  {server, [{'<<',1}, {string,1,"r.com"}, {'>>',1}]}
+                ]
+              }}]}
+          ]
+        }
+      },
+      {dot,1}
+    ],
+    R1
+  ),
+
+  R2 = parse_records(
+    [{myrecord, [firstname,age,now]}],
+    scan("#myrecord{now = 2019, firstname = <<\"Frank\">>, age = {over, 20}}"),
+    []
+  ),
+
+  ?assertEqual([
+      {record,
+        {
+          myrecord,
+          [firstname,age,now],
+          [
+            {age,[?LEX_OPEN_BRACE, {atom,1,over}, ?LEX_COMMA, {integer,1,20}, ?LEX_CLOSE_BRACE]},
+            {firstname,[{'<<',1},{string,1,"Frank"},{'>>',1}]},
+            {now,[{integer,1,2019}]}
+          ]
+        }
+      },
+      {dot,1}
+    ],
+    R2
+  ),
+
+  R3 = parse_record(
+    [{myrecord, [firstname,age,now]}],
+    myrecord,
+    [firstname,age,now],
+    scan("now = 2019, firstname = <<\"Frank\">>, age = {over, 20}}")
+  ),
+
+  ?assertEqual({
+      {record,
+        {
+          myrecord,
+          [firstname,age,now],
+          [
+            {age,[?LEX_OPEN_BRACE, {atom,1,over}, ?LEX_COMMA, {integer,1,20}, ?LEX_CLOSE_BRACE]},
+            {firstname,[{'<<',1},{string,1,"Frank"},{'>>',1}]},
+            {now,[{integer,1,2019}]}
+          ]
+        }
+      }, [
+        {dot,1}
+      ]
+    },
+    R3
+  ),
+
+  R4 = replace_records([
+    {myrecord, [firstname,age,now]},
+    {jid, [user,server,resource]}
+  ], scan("#myrecord{now = #jid{server = <<\"xmpp.com\">>}, firstname = <<\"Frank\">>, age = {over, 20}}")),
+
+  ?assertEqual([
+      ?LEX_OPEN_BRACE,
+      {atom,1,myrecord},
+      ?LEX_COMMA,
+      {'<<',1},
+      {string,1,"Frank"},
+      {'>>',1},
+      ?LEX_COMMA,
+      ?LEX_OPEN_BRACE,
+      {atom,1,over},
+      ?LEX_COMMA,
+      {integer,1,20},
+      ?LEX_CLOSE_BRACE,
+      ?LEX_COMMA,
+      ?LEX_OPEN_BRACE,
+      {atom,1,jid},
+      ?LEX_COMMA,
+      ?LEX_ANY,
+      ?LEX_COMMA,
+      {'<<',1},
+      {string,1,"xmpp.com"},
+      {'>>',1},
+      ?LEX_COMMA,
+      ?LEX_ANY,
+      ?LEX_CLOSE_BRACE,
+      ?LEX_CLOSE_BRACE,
+      {dot,1}
+    ],
+    R4
+  ),
+
+  R5 = replace_records([
+    {myrecord, [firstname,age,now]}
+  ], scan("hello:run(#myrecord{now = 2019}, 90)")),
+  ?assertEqual([
+    {atom,1,hello},
+    ?LEX_COLUMN,
+    {atom,1,run},
+    {'(',1},
+    ?LEX_OPEN_BRACE,
+    {atom,1,myrecord},
+    ?LEX_COMMA,
+    ?LEX_ANY,
+    ?LEX_COMMA,
+    ?LEX_ANY,
+    ?LEX_COMMA,
+    {integer,1,2019},
+    ?LEX_CLOSE_BRACE,
+    ?LEX_COMMA,
+    {integer,1,90},
+    {')',1},
+    {dot,1}],
+    R5
+  )
+.
+
+-endif.

--- a/src/redbug_msc.erl
+++ b/src/redbug_msc.erl
@@ -206,8 +206,10 @@ body(Str) ->
     {done,{ok,Toks0,1},[]} ->
       Toks = case Toks0 of
         [{atom,1,Module},?LEX_COLUMN | _] ->
-          Defs = scan_records(read_records(Module, []), []),
-          replace_records(Defs, Toks0);
+          case catch scan_records(read_records(Module, []), []) of
+                   R when is_list(R) -> replace_records(R, Toks0);
+                   _ -> Toks0
+          end;
         _ -> Toks0
       end,
       case erl_parse:parse_exprs(Toks) of
@@ -369,7 +371,6 @@ rewrite_records([E | T], L) ->
 
 %%% create a property list with all records (in abstract code)
 
-scan_records([], X) when not is_list(X) -> [];
 scan_records([], L) -> L;
 scan_records([{attribute,_,record, {Name, Fields}} | T], L) ->
   scan_records(T, [scan_record(Name, Fields) | L]);


### PR DESCRIPTION
Hi,

Miserably, I didn't saw the work in progress in your "records" branch :-(
Well, I gave it a try but didn't succeed to use records with the # syntax.
Is this support finalized ? Could you provide a sample please ?

I added records support for the # syntax of records to your master branch (if anyone is interested) :

```code
1> rr(file).
2> redbug:start("file:write_file_info(\"/tmp/dummy.txt\", #file_info{mode = 33188})").                          
{793,1}
3> file:write_file_info("/tmp/dummy.txt", #file_info{mode = 33188}).                  
% 01:15:11 <0.1087.0>({erlang,apply,2})
% file:write_file_info("/tmp/dummy.txt", {file_info,undefined,undefined,undefined,undefined,undefined,undefined,33188,
           undefined,undefined,undefined,undefined,undefined,undefined})
ok
```

Many thanks for your great tool ;-)