### PR TITLE
Relax pattern matching for beam_lib:chunks/2 in case of errors

### DIFF
--- a/src/redbug_targ.erl
+++ b/src/redbug_targ.erl
@@ -131,7 +131,7 @@ locals(M) ->
       case beam_lib:chunks(F,[locals]) of
         {ok,{M,[{locals,Locals}]}} ->
           Locals;
-        {error,beam_lib,{missing_chunk,_,_}} ->
+        {error,beam_lib,_} ->
           []
       end
   end.


### PR DESCRIPTION
`beam_lib:chunks/2` can fail with errors other than `missing_chunk`. For example, when using redbug to debug an `escript`, `redbug:start/1` will crash if you start tracing a function which belongs to one of the _zipped_ modules with something like:

```
{{case_clause,{error,beam_lib,
                     {file_error,"/PATH/TO/ESCRIPT/APPLICATION/ebin/MODULE.beam",
                                 enotdir}}},
 [{redbug_targ,locals,1,
               [{file,"/Users/robert.aloi/git/github/erlang-ls/erlang_ls/_build/debug/lib/redbug/src/redbug_targ.erl"},
                {line,131}]},
```

This PR relaxes a bit the pattern matching so that more errors can be "tolerated".