### PR TITLE
Use erl_prim_loader in case file is an ez

### DIFF
--- a/src/redbug_targ.erl
+++ b/src/redbug_targ.erl
@@ -128,7 +128,8 @@ locals(M) ->
   case code:which(M) of
     preloaded -> [];
     F ->
-      case beam_lib:chunks(F,[locals]) of
+      {ok,Bin,_FullName} = erl_prim_loader:get_file(F),
+      case beam_lib:chunks(Bin,[locals]) of
         {ok,{M,[{locals,Locals}]}} ->
           Locals;
         {error,beam_lib,{missing_chunk,_,_}} ->


### PR DESCRIPTION
Without this change I would get the following when tracing certain modules that are contained in `.ez` archives:

```
2019-09-23 13:53:39.823 [error] emulator Error in process <0.1317.0> on node rabbit@shostakovich with exit value:
{{case_clause,{error,beam_lib,{file_error,"/home/lbakken/development/rabbitmq/umbrella/deps/rabbitmq_server_release/plugins/rabbit_common-3.8.0+beta.7.2.gac48182.ez/rabbit_common-3.8.0+beta.7.2.gac48182/ebin/rabbit_event.beam",enotdir}}},[{prfTrc,locals,1,[{file,"/home/lbakken/development/massemanet/eper/src/prfTrc.erl"},{line,139}]},{prfTrc,functions,1,[{file,"/home/lbakken/development/massemanet/eper/src/prfTrc.erl"},{line,130}]},{prfTrc,arities,2,[{file,"/home/lbakken/development/massemanet/eper/src/prfTrc.erl"},{line,133}]},{prfTrc,expand_underscore,2,[{file,"/home/lbakken/development/massemanet/eper/src/prfTrc.erl"},{line,122}]},{lists,foldl,3,[{file,"lists.erl"},{line,1263}]},{prfTrc,start_trace,2,[{file,"/home/lbakken/development/massemanet/eper/src/prfTrc.erl"},{line,103}]},{prfTrc,idle,0,[{file,"/home/lbakken/development/massemanet/eper/src/prfTrc.erl"},{line,61}]}]}
```