### PR TITLE
Use peer instead of slave when OTP-25

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ notifications:
   email: false
 
 otp_release:
+  - 25.0
+  - 24.2
+  - 23.3.1
   - 22.2
   - 21.3
   - 20.3

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,8 @@
 %-*- mode: erlang; erlang-indent-level: 2 -*-
 {plugins,             [rebar3_hex]}.
-{erl_opts,            [debug_info, warnings_as_errors]}.
+{erl_opts,            [debug_info, warnings_as_errors,
+                       {platform_define, "^(R|1|20)", 'OTP_20_OR_EARLIER'},
+                       {platform_define, "^(R|1|20|21|22|23|24)", 'OTP_24_OR_EARLIER'}]}.
 {xref_checks,         [undefined_function_calls]}.
 {cover_enabled,       true}.
 {cover_print_enabled, true}.


### PR DESCRIPTION
At OTP-25-rc2, warning shows up and build fails

```
  src/redbug_targ.erl:545:17: ct_slave:start/2 is deprecated and will be removed in OTP 27;
  use ?CT_PEER(), or the 'peer' module instead
```

