### PR TITLE
Have node as part of the name for redbug process; use universal time for timestamps

### DIFF
--- a/src/redbug.erl
+++ b/src/redbug.erl
@@ -10,8 +10,9 @@
 
 -export([help/0]).
 -export([start/1, start/2]).
--export([stop/0]).
+-export([stop/0, stop/1]).
 -export([dtop/0, dtop/1]).
+-export([redbug_name/1]).
 
 -define(
    log(T),
@@ -167,7 +168,10 @@ dtop_cfg(Cfg) ->
 %% Stops a trace.
 %% @end
 stop() ->
-  case whereis(redbug) of
+  stop(erlang:node()).
+
+stop(Target) ->
+  case whereis(redbug_name(Target)) of
     undefined -> not_started;
     Pid -> Pid ! stop, stopped
   end.
@@ -186,17 +190,20 @@ start(Trc, Props) when is_map(Props) ->
 %%% the real start function!
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 start(Trc, Props) when is_list(Props) ->
-  case whereis(redbug) of
+  RedbugName = redbug_name(Props),
+  case whereis(RedbugName) of
     undefined ->
       try
         Cnf = assert_print_fun(make_cnf(Trc, [{shell_pid, self()}|Props])),
         assert_cookie(Cnf),
-        register(redbug, spawn(fun() -> init(Cnf) end)),
-        maybe_block(Cnf, block_a_little())
+        register(RedbugName, spawn(fun() -> init(Cnf) end)),
+      
+        maybe_block(Cnf, block_a_little(RedbugName))
       catch
         R   -> R;
         C:R -> {oops, {C, R}}
-      end;
+      end
+      ;
     _ ->
       redbug_already_started
   end.
@@ -216,18 +223,18 @@ mk_print_fun(Cnf) ->
 assert_cookie(#cnf{cookie=''}) -> ok;
 assert_cookie(Cnf) -> erlang:set_cookie(Cnf#cnf.target, Cnf#cnf.cookie).
 
-block_a_little() ->
-  Ref = erlang:monitor(process, redbug),
+block_a_little(ProcessName) ->
+  Ref = erlang:monitor(process, ProcessName),
   receive
-    {running, NoP, NoF}  -> erlang:demonitor(Ref), {NoP, NoF};
+    {running, NoP, NoF}  -> erlang:demonitor(Ref), {ProcessName, NoP, NoF};
     {'DOWN', Ref, _, _, R} -> R
   end.
 
-maybe_block(#cnf{blocking=true}, {I, _}) when is_integer(I) -> block();
+maybe_block(#cnf{blocking=true}, {ProcessName, I, _}) when is_integer(I) -> block(ProcessName);
 maybe_block(_, R) -> R.
 
-block() ->
-  Ref = erlang:monitor(process, redbug),
+block(ProcessName) ->
+  Ref = erlang:monitor(process, ProcessName),
   receive
     {'DOWN', Ref, _, _, R} -> R
   end.
@@ -653,3 +660,10 @@ human(E, M) ->
 
 flat(Format, Args) ->
   lists:flatten(io_lib:fwrite(Format, Args)).
+
+redbug_name(Opts) when is_list(Opts) ->
+  Node = proplists:get_value(target, Opts, erlang:node()),
+  redbug_name(Node);
+
+redbug_name(Node) when is_atom(Node) ->
+  list_to_atom("redbug_" ++ atom_to_list(Node)).

--- a/src/redbug_targ.erl
+++ b/src/redbug_targ.erl
@@ -473,7 +473,7 @@ mk_unreg_name(P) ->
   end.
 
 ts(Nw) ->
-  {_, {H, M, S}} = calendar:now_to_local_time(Nw),
+  {_, {H, M, S}} = calendar:now_to_universal_time(Nw),
   {H, M, S, element(3, Nw)}.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
- Having a node as part of the process name will enable running several instances of redbug on one node.
The motivation is to collect traces across several nodes in one place.
- Using UTC time will also help to analyze the traces from several nodes without having to figure out the differences in local times/TZ. 
