### PR TITLE
Update rebar.config for xref failed

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,13 @@
 %-*- mode: erlang; erlang-indent-level: 2 -*-
 {plugins,             [rebar3_hex]}.
-{erl_opts,            [debug_info, warnings_as_errors]}.
+
+{erl_opts,  [debug_info, warnings_as_errors,
+             {extra_src_dirs,
+                [{"test", [{recursive, true}]}]
+             }
+            ]
+}.
+
 {xref_checks,         [undefined_function_calls]}.
 {cover_enabled,       true}.
 {cover_print_enabled, true}.


### PR DESCRIPTION
add test src dir for xref error:
===> 
src/redbug_targ.erl:539: Warning: redbug_targ:netload1/0 calls undefined function redbug_dist_eunit:start_peer/0 (Xref) src/redbug_targ.erl:539: Warning: redbug_targ:netload1/0 calls undefined function redbug_dist_eunit:stop_peer/2 (Xref) src/redbug_targ.erl:544: Warning: redbug_targ:netload2/0 calls undefined function redbug_dist_eunit:start_peer/0 (Xref) src/redbug_targ.erl:544: Warning: redbug_targ:netload2/0 calls undefined function redbug_dist_eunit:stop_peer/2 (Xref)