### PR TITLE
redbug_dtop: fix handling of -0.0 for OTP-26.1/27.0

### DIFF
--- a/src/redbug_dtop.erl
+++ b/src/redbug_dtop.erl
@@ -222,7 +222,7 @@ cpu_per_red(SysData) ->
 
 cpu(SysData) ->
     case pull_sys_d(beam_user, SysData) + pull_sys_d(beam_kernel, SysData) of
-        0.0 -> 1;
+        C when C == 0.0 -> 1;
         C -> C
     end.
 


### PR DESCRIPTION
Matching of floating-point zeroes will change in OTP-27 so that -0.0 will no longer match a non-negative 0.0. OTP-26.1 warns about such constructs, which in redbug results in:

===> Compiling src/redbug_dtop.erl failed
src/redbug_dtop.erl:225:9: matching on the float 0.0 will no longer also match -0.0 in OTP 27. If you specifically intend to match 0.0 alone, write +0.0 instead.

Fixed by switching from a match to a numerical comparison.