### PR TITLE
redbug_dtop: don't crash when racing with process termination

### DIFF
--- a/src/redbug_dtop.erl
+++ b/src/redbug_dtop.erl
@@ -616,6 +616,9 @@ prcinfo(heap_size, _) ->
 prcinfo(total_heap_size, _) ->
     {fun(Val) -> 8*Val end,
      0};
+prcinfo(reductions, _) ->
+    {fun(Val) -> Val end,
+     0};
 prcinfo(last_calls, Pid) ->
     {fun(Val) ->
              case Val of


### PR DESCRIPTION
If a process terminates between the list of processes is retrieved in get_prc_data/1 and its reductions are recorded in prc_info/1, then the recorded value will be [] and not a number. Later on as complete/2 is called on the recorded data, a badarith crash occurs because it multiplies a number with that [].

prcinfo/2 needs a clause for reductions which returns 0 not [] as default value for a terminated process.