### PR TITLE
Added option print_node::boolean()

### DIFF
--- a/doc/start.edoc
+++ b/doc/start.edoc
@@ -74,6 +74,7 @@ print-related opts
     print_depth  (999999)      formatting depth for "~P"
     print_re     ("")          print only strings that match this regexp
     print_return (true)        print return value
+    print_node   (false)       print node name of traced pid
     print_fun    ('')          custom print fun. gets called once for each trace
                                message. It can be a fun/1, (called as F(Msg),
                                return value is ignored), or a fun/2 (called as


### PR DESCRIPTION
print_node=true will include the node name of Pid in output.

e.g.
redbug:start("io:format", #{print_node => true}).

% 12:13:41 node1@bedaro <0.91.0>({erlang,apply,2}) 
% io:format("hello redbug~n", [])

This is convenient when running redbug on several nodes in parallell. 

Works with both following methods for starting trace on a remote node

[redbug:start("mod:func", #{target => Node, print_node => true}) || Node <- Nodes]

[rpc:call(Node, redbug, start, ["mod:func", #{print_node => true}]) || Node <- Nodes]


