### PR TITLE
Dialyzer + net_kernel:start options

### DIFF
--- a/src/redbug.erl
+++ b/src/redbug.erl
@@ -176,7 +176,13 @@ handle_args([Trc | Rest], Config = #cnf{trc = Trcs}) ->
 -endif.
 
 %% net_kernel:start/2 was introduced in OTP 24.3
--if(?OTP_RELEASE >= 25).
+%% hidden-option was added to start options in OTP 25.1
+-if(?OTP_RELEASE >= 26).
+start_distribution(Cnf) ->
+    DistOptions = #{name_domain => name_domain(Cnf), hidden => true},
+    {ok, _} = net_kernel:start(random_node_name(), DistOptions),
+    assert_cookie(Cnf).
+-elif(?OTP_RELEASE >= 25).
 start_distribution(Cnf) ->
     DistOptions = #{name_domain => name_domain(Cnf)},
     {ok, _} = net_kernel:start(random_node_name(), DistOptions),

--- a/src/redbug.erl
+++ b/src/redbug.erl
@@ -171,10 +171,22 @@ handle_args([Trc | Rest], Config = #cnf{trc = Trcs}) ->
     %% Any following non-option arguments are trace patterns.
     handle_args(Rest, Config#cnf{trc = Trcs++[trc(Trc)]}).
 
+-ifndef(OTP_RELEASE).
+-define(OTP_RELEASE, 0).
+-endif.
+
+%% net_kernel:start/2 was introduced in OTP 24.3
+-if(?OTP_RELEASE >= 25).
 start_distribution(Cnf) ->
-    DistOptions = #{name => random_node_name(), name_domain => name_domain(Cnf), hidden => true},
+    DistOptions = #{name_domain => name_domain(Cnf)},
+    {ok, _} = net_kernel:start(random_node_name(), DistOptions),
+    assert_cookie(Cnf).
+-else.
+start_distribution(Cnf) ->
+    DistOptions = [random_node_name(), name_domain(Cnf)],
     {ok, _} = net_kernel:start(DistOptions),
     assert_cookie(Cnf).
+-endif.
 
 random_node_name() ->
     list_to_atom("redbug-" ++ integer_to_list(rand:uniform(1000000000))).
@@ -340,7 +352,13 @@ stop(Target) ->
 start(RTPs) ->
     start(RTPs, []).
 
--spec start(RTPs::list(), Opts::map()) -> {Procs::integer(), Functions::integer()}.
+-type rtps() :: list() | 'send' | 'receive'.
+-type start_opts() :: map() | list(proplists:property()).
+-type redbug_name() :: atom().
+-spec start(RTPs::rtps(), Opts::start_opts()) ->
+          {Name::redbug_name(), Procs::integer(), Functions::integer()}
+              | redbug_already_started
+              | {timeout, any()}.
 
 start('send', Props)    -> start([send], Props);
 start('receive', Props) -> start(['receive'], Props);


### PR DESCRIPTION
net_kernel:start/2 was introduced in OTP 24.3, where first argument is the name, and the second arguments are specific options as a map.
The 'hidden' option was introduced in OTP-25.1 for the start-function.

net_kernel:start/1 takes a list of at maximum three elements as argument, the Name, NameDomain, and TickTime.

if start/1,2 receives unknown options they will throw an invalid_option error.