### PR TITLE
Refactor eunit tests

### DIFF
--- a/src/redbug.erl
+++ b/src/redbug.erl
@@ -354,7 +354,18 @@ stop() ->
 stop(Target) ->
     case whereis(redbug_name(Target)) of
         undefined -> not_started;
-        Pid -> Pid ! stop, stopped
+        Pid ->
+            sync_stop(Pid)
+    end.
+
+sync_stop(Pid) ->
+    Ref = erlang:monitor(process, Pid),
+    Pid ! stop,
+    receive
+        {'DOWN', Ref, process, Pid, _} -> stopped
+    after 5000 ->
+            erlang:demonitor(Ref, [flush]),
+            {error, timeout}
     end.
 
 %% @equiv start(RTPs, [])

--- a/test/redbug_eunit.erl
+++ b/test/redbug_eunit.erl
@@ -268,14 +268,15 @@ loct_stripped_non_arity_return_test_() ->
              redbug_start(?FUNCTION_NAME, "stripped_mod:local_fun->return", []),
              M:exported_fun(5),
              redbug_normal_stop(),
-             unload_module(M),
-             redbug_output(?FUNCTION_NAME)
+             Content = redbug_output(?FUNCTION_NAME),
+             {M, Content}
      end,
-     fun (_Content) ->
+     fun ({M, _Content}) ->
+             unload_module(M),
              Filename = output_filename(?FUNCTION_NAME),
              maybe_delete(Filename)
      end,
-     fun (Content) ->
+     fun ({_M, Content}) ->
              [?_assertEqual(<<"stripped_mod:local_fun(5)">>,
                             get_line_seg(Content, 2, 2)),
               ?_assertEqual([<<"stripped_mod:local_fun/1">>, <<"->">>, <<"10">>],
@@ -289,14 +290,15 @@ loct_stripped_full_module_return_test_() ->
              redbug_start(?FUNCTION_NAME, "stripped_mod->return", []),
              M:exported_fun(5),
              redbug_normal_stop(),
-             unload_module(M),
-             redbug_output(?FUNCTION_NAME)
+             Content = redbug_output(?FUNCTION_NAME),
+             {M, Content}
      end,
-     fun (_Content) ->
+     fun ({M, _Content}) ->
+             unload_module(M),
              Filename = output_filename(?FUNCTION_NAME),
              maybe_delete(Filename)
      end,
-     fun (Content) ->
+     fun ({_M, Content}) ->
              [?_assertEqual(<<"stripped_mod:local_fun(5)">>,
                             get_line_seg(Content, 4, 2)),
               ?_assertEqual([<<"stripped_mod:local_fun/1">>, <<"->">>, <<"10">>],
@@ -310,14 +312,15 @@ loct_stripped_non_arity_count_test_() ->
              redbug_start(?FUNCTION_NAME, "stripped_mod:local_fun->count", []),
              M:exported_fun(5),
              redbug_normal_stop(),
-             unload_module(M),
-             redbug_output(?FUNCTION_NAME)
+             Content = redbug_output(?FUNCTION_NAME),
+             {M, Content}
      end,
-     fun (_Content) ->
+     fun ({M, _Content}) ->
+             unload_module(M),
              Filename = output_filename(?FUNCTION_NAME),
              maybe_delete(Filename)
      end,
-     fun (Content) ->
+     fun ({_M, Content}) ->
              [?_assertEqual(<<"stripped_mod:local_fun(5)">>,
                             get_line_seg(Content, 2, 2)),
               ?_assertEqual(<<"stripped_mod:local_fun/1">>,
@@ -331,14 +334,15 @@ loct_stripped_full_module_count_test_() ->
              redbug_start(?FUNCTION_NAME, "stripped_mod->count", []),
              M:exported_fun(5),
              redbug_normal_stop(),
-             unload_module(M),
-             redbug_output(?FUNCTION_NAME)
+             Content = redbug_output(?FUNCTION_NAME),
+             {M, Content}
      end,
-     fun (_Content) ->
+     fun ({M, _}) ->
+             unload_module(M),
              Filename = output_filename(?FUNCTION_NAME),
              maybe_delete(Filename)
      end,
-     fun (Content) ->
+     fun ({_M, Content}) ->
              [?_assertEqual(<<"stripped_mod:local_fun(5)">>,
                             get_line_seg(Content, 4, 2)),
               ?_assertEqual(<<"stripped_mod:local_fun/1">>,

--- a/test/redbug_eunit.erl
+++ b/test/redbug_eunit.erl
@@ -256,9 +256,9 @@ blocking_test_() ->
               %%  {call,{{erlang,monitor,2},<<>>},
               %%        {<0.445.0>,{erlang,apply,2}},
               %%        {20,10,36,706695}}]
-              [?_assertEqual([{erlang, demonitor, 1},
-                              {erlang, monitor, 2}],
-                             [MFA || {call, {MFA, _}, _, _} <- Msgs])]
+              [?_assertMatch([{call, {{erlang, demonitor, 1}, _}, _, _},
+                              {call, {{erlang, monitor, 2}, _}, _, _}],
+                             Msgs)]
       end}}.
 
 trace_file_test_() ->
@@ -278,10 +278,9 @@ trace_file_test_() ->
               %% Example output:
               %% [{trace_ts,<0.445.0>,return_from,{lists,sort,1},[1,2,3],{1778,443837,230786}},
               %%  {trace_ts,<0.445.0>,call,{lists,sort,[[3,2,1]]},{1778,443837,230776}}]
-              [?_assertEqual(sort,
-                             e(2, e(4, e(1, Msgs)))),
-               ?_assertEqual(sort,
-                             e(2, e(4, e(2, Msgs))))]
+              [?_assertMatch([{trace_ts, _, return_from, {lists, sort, 1}, [1, 2, 3], _},
+                              {trace_ts, _, call, {lists, sort, [[3, 2, 1]]}, _}],
+                             Msgs)]
       end}}.
 
 no_return_test_() ->

--- a/test/redbug_eunit.erl
+++ b/test/redbug_eunit.erl
@@ -5,176 +5,134 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-t_0_test() ->
-  Filename = "redbug0.txt",
-  {_, _, _} = redbug:start("lists:sort", [{print_file, Filename}, print_msec, debug]),
+millisecond_test() ->
+  redbug_start(?FUNCTION_NAME, "lists:sort", [print_msec]),
   [1, 2, 3] = lists:sort([3, 2, 1]),
-  timer:sleep(100),
-  redbug:stop(),
-  timer:sleep(100),
-  maybe_show(Filename),
-  TS = re:split(get_line_seg(Filename, 1, 2), "[:.]"),
+  redbug_normal_stop(),
+  Content = redbug_output(?FUNCTION_NAME),
+  Timestamp = get_line_seg(Content, 1, 2),
+  Re = re:run(Timestamp, "(.*)[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}(.*)", [{capture, all}]),
   ?assertEqual(<<"lists:sort([3,2,1])">>,
-               get_line_seg(Filename, 2, 2)),
-  ?assertEqual(4,
-               length(TS)),
-  ?assertEqual(3,
-               size(lists:last(TS))),
-  maybe_delete(Filename).
+               get_line_seg(Content, 2, 2)),
+  ?assertEqual({match, [{0,12}, {0,0}, {12,0}]}, Re).
 
-t_01_test() ->
-  Filename = "redbug01.txt",
-  {_, _, _} = redbug:start("lists:sort", [{print_file, Filename}, arity, debug]),
+arity_test() ->
+  redbug_start(?FUNCTION_NAME, "lists:sort", [arity]),
   [1, 2, 3] = lists:sort([3, 2, 1]),
-  timer:sleep(100),
-  redbug:stop(),
-  timer:sleep(100),
-  maybe_show(Filename),
+  redbug_normal_stop(),
+  Content = redbug_output(?FUNCTION_NAME),
   ?assertEqual(<<"lists:sort/1">>,
-               get_line_seg(Filename, 2, 2)),
+               get_line_seg(Content, 2, 2)),
   ?assertEqual(3,
-               length(re:split(get_line_seg(Filename, 1, 2), "[:.]"))),
-  maybe_delete(Filename).
+               length(re:split(get_line_seg(Content, 1, 2), "[:.]"))).
 
-t_02_test() ->
-  Filename = "redbug02.txt",
-  {_, _, _} = redbug:start("lists:sort", [{print_file, Filename}, {print_time_unit, microsecond}, debug]),
+microsecond_test() ->
+  redbug_start(?FUNCTION_NAME, "lists:sort", [{print_time_unit, microsecond}]),
   [1, 2, 3] = lists:sort([3, 2, 1]),
-  timer:sleep(100),
-  redbug:stop(),
-  timer:sleep(100),
-  maybe_show(Filename),
-  TS = re:split(get_line_seg(Filename, 1, 2),"[:.]"),
+  redbug_normal_stop(),
+  Content = redbug_output(?FUNCTION_NAME),
+  Timestamp = get_line_seg(Content, 1, 2),
+  Re = re:run(Timestamp, "(.*)[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{6}(.*)", [{capture, all}]),
   ?assertEqual(<<"lists:sort([3,2,1])">>,
-               get_line_seg(Filename, 2, 2)),
-  ?assertEqual(4,
-               length(TS)),
-  ?assertEqual(6,
-               size(lists:last(TS))),
-  maybe_delete(Filename).
+               get_line_seg(Content, 2, 2)),
+  ?assertEqual({match, [{0,15}, {0,0}, {15,0}]}, Re).
 
-t_1_test() ->
-  Filename = "redbug1.txt",
-  {_, _, _} = redbug:start("lists:sort->return", [{print_file, Filename}, buffered, debug]),
+buffered_test() ->
+  redbug_start(?FUNCTION_NAME, "lists:sort->return", [buffered]),
   [1, 2, 3] = lists:sort([3, 2, 1]),
-  timer:sleep(100),
-  redbug:stop(),
-  timer:sleep(100),
-  maybe_show(Filename),
+  redbug_normal_stop(),
+  Content = redbug_output(?FUNCTION_NAME),
   ?assertEqual(<<"lists:sort([3,2,1])">>,
-               get_line_seg(Filename, 2, 2)),
+               get_line_seg(Content, 2, 2)),
   ?assertEqual([<<"lists:sort/1">>, <<"->">>, <<"[1,2,3]">>],
-               get_line_seg(Filename, 4, 2, 4)),
-  maybe_delete(Filename).
+               get_line_seg(Content, 4, 2, 4)).
 
-t_2_test() ->
-  Filename = "redbug2.txt",
-  {_, _, _} = redbug:start("lists:sort->stack", [{print_file, Filename}, debug]),
+return_stack_test() ->
+  redbug_start(?FUNCTION_NAME, "lists:sort->stack", []),
   [1, 2, 3] = lists:sort([3, 2, 1]),
-  timer:sleep(100),
-  redbug:stop(),
-  timer:sleep(100),
-  maybe_show(Filename),
+  redbug_normal_stop(),
+  Content = redbug_output(?FUNCTION_NAME),
   ?assertEqual(<<"lists:sort([3,2,1])">>,
-               get_line_seg(Filename, 2, 2)),
-  Lines = lists:seq(3, lines(Filename)-1),
+               get_line_seg(Content, 2, 2)),
+  Lines = lists:seq(3, lines(Content)-1),
   ?assertEqual([true],
-               lists:usort([is_mfa(get_line_seg(Filename, L, 2))||L<-Lines])),
-  maybe_delete(Filename).
+               lists:usort([is_mfa(get_line_seg(Content, L, 2))||L<-Lines])).
 
-t_3_test() ->
-  Filename = "redbug3.txt",
+proc_send_test() ->
   Pid = spawn(fun()->receive P when is_pid(P)->P!ding;quit->ok end end),
-  {_, _, _} = redbug:start(send, [{procs, Pid}, {print_file, Filename}, debug]),
+  redbug_start(?FUNCTION_NAME, send, [{procs, Pid}]),
   Pid ! self(),
-  timer:sleep(100),
-  redbug:stop(),
-  timer:sleep(100),
-  maybe_show(Filename),
+  redbug_normal_stop(),
+  Content = redbug_output(?FUNCTION_NAME),
   ?assertEqual(<<"ding">>,
-               get_line_seg(Filename, 2, 4)),
-  maybe_delete(Filename).
+               get_line_seg(Content, 2, 4)).
 
-t_4_test() ->
-  Filename = "redbug4.txt",
+proc_receive_test() ->
   Pid = spawn(fun()->receive P when is_pid(P)->P!ding;quit->ok end end),
-  {_, _, _} = redbug:start('receive', [{procs, Pid}, {print_file, Filename}, debug]),
+  redbug_start(?FUNCTION_NAME, 'receive', [{procs, Pid}]),
   Pid ! pling,
-  timer:sleep(100),
-  redbug:stop(),
-  timer:sleep(100),
-  maybe_show(Filename),
+  redbug_normal_stop(),
+  Content = redbug_output(?FUNCTION_NAME),
   ?assertEqual(<<"pling">>,
-               get_line_seg(Filename, 2, 3)),
-  maybe_delete(Filename).
+               get_line_seg(Content, 2, 3)).
 
-t_5_test() ->
-  Filename = "redbug5.txt",
-  {_, _, _} = redbug:start("lists:sort->time", [{print_file, Filename}, {time, 999}, debug]),
+call_time_test() ->
+  redbug_start(?FUNCTION_NAME, "lists:sort->time", []),
   [1, 2, 3] = lists:sort([3, 2, 1]),
-  timer:sleep(1100),
-  maybe_show(Filename),
+  redbug_normal_stop(),
+  Content = redbug_output(?FUNCTION_NAME),
   ?assertEqual(<<"lists:sort([3,2,1])">>,
-               get_line_seg(Filename, 2, 2)),
+               get_line_seg(Content, 2, 2)),
   ?assertEqual(<<"lists:sort/1">>,
-               get_line_seg(Filename, 3, 8)),
-  maybe_delete(Filename).
+               get_line_seg(Content, 3, 8)).
 
-t_6_test() ->
-  Filename = "redbug6.txt",
-  {_, _, _} = redbug:start("lists:sort->count", [{print_file, Filename}, {time, 999}, debug]),
+call_count_test() ->
+  redbug_start(?FUNCTION_NAME, "lists:sort->count", []),
   [1, 2, 3] = lists:sort([3, 2, 1]),
-  timer:sleep(1100),
-  maybe_show(Filename),
+  redbug_normal_stop(),
+  Content = redbug_output(?FUNCTION_NAME),
   ?assertEqual(<<"lists:sort([3,2,1])">>,
-               get_line_seg(Filename, 2, 2)),
+               get_line_seg(Content, 2, 2)),
   ?assertEqual(<<"lists:sort/1">>,
-               get_line_seg(Filename, 3, 4)),
-  maybe_delete(Filename).
+               get_line_seg(Content, 3, 4)).
 
-t_7_test() ->
-  Os = [blocking, {time, 999}, {msgs, 1000}, arity, debug],
-  {timeout, Msgs} = redbug:start(["erlang:demonitor", "erlang:monitor"], Os),
+blocking_test() ->
+  Options = [blocking, arity, {time, 499}, debug],
+  {timeout, Msgs} = redbug:start(["erlang:demonitor", "erlang:monitor"], Options),
   ?assertEqual([{erlang, demonitor, 1},
                 {erlang, monitor, 2}],
                [MFA || {call, {MFA, _}, _, _} <- Msgs]).
 
-t_8_test() ->
-  {_, _, _} = redbug:start("lists:sort->return", [{file, "foo"}, {time, 999}, debug]),
+trace_file_test() ->
+  redbug_start(?FUNCTION_NAME, "lists:sort->return", [{file, "foo"}]),
   [1, 2, 3] = lists:sort([3, 2, 1]),
-  timer:sleep(1100),
+  redbug_normal_stop(),
   {2, Msgs} = replay_trc:go("foo0.trc", fun(E, A) -> [E]++A end, []),
+  maybe_delete("foo0.trc"),
   ?assertEqual(sort,
                e(2, e(4, e(1, Msgs)))),
   ?assertEqual(sort,
-               e(2, e(4, e(2, Msgs)))),
-  maybe_delete("foo0.trc").
+               e(2, e(4, e(2, Msgs)))).
 
-t_9_test() ->
-  Filename = "redbug9.txt",
-  Options = [{print_file, Filename}, {time, 999}, {print_return, false}],
-  {_, _, _} = redbug:start("lists:sort->return", [debug|Options]),
+no_return_test() ->
+  redbug_start(?FUNCTION_NAME, "lists:sort->return", [{print_return, false}]),
   [1, 2, 3] = lists:sort([3, 2, 1]),
-  timer:sleep(1100),
-  maybe_show(Filename),
+  redbug_normal_stop(),
+  Content = redbug_output(?FUNCTION_NAME),
   ?assertEqual(<<"lists:sort([3,2,1])">>,
-               get_line_seg(Filename, 2, 2)),
+               get_line_seg(Content, 2, 2)),
   ?assertEqual([<<"lists:sort/1">>, <<"->">>, <<"'...'">>],
-               get_line_seg(Filename, 4, 2, 4)),
-  maybe_delete(Filename).
+               get_line_seg(Content, 4, 2, 4)).
 
-t_10_test() ->
-  Filename = "redbug10.txt",
-  Options = [{print_file, Filename}, {time, 999}],
-  {_, _, _} = redbug:start("redbug_eunit:ipl()->return", [debug|Options]),
+improper_list_test() ->
+  redbug_start(?FUNCTION_NAME, "redbug_eunit:ipl()->return", []),
   ipl(),
-  timer:sleep(1100),
-  maybe_show(Filename),
+  redbug_normal_stop(),
+  Content = redbug_output(?FUNCTION_NAME),
   ?assertEqual(<<"redbug_eunit:ipl()">>,
-               get_line_seg(Filename, 2, 2)),
+               get_line_seg(Content, 2, 2)),
   ?assertEqual([<<"redbug_eunit:ipl/0">>, <<"->">>, <<"[a,b|c]">>],
-               get_line_seg(Filename, 4, 2, 4)),
-  maybe_delete(Filename).
+               get_line_seg(Content, 4, 2, 4)).
 
 %% test printing of improper lists
 ipl() -> [a, b|c].
@@ -205,9 +163,9 @@ loct_stripped_full_module_return_test() ->
 
 loct_stripped_non_arity_count_test() ->
   M = load_stripped_module(),
-  redbug_start(?FUNCTION_NAME, "stripped_mod:local_fun->count", [{time, 999}]),
+  redbug_start(?FUNCTION_NAME, "stripped_mod:local_fun->count", []),
   M:exported_fun(5),
-  redbug_timeout_stop(),
+  redbug_normal_stop(),
   unload_module(M),
   Content = redbug_output(?FUNCTION_NAME),
   ?assertEqual(<<"stripped_mod:local_fun(5)">>,
@@ -217,9 +175,9 @@ loct_stripped_non_arity_count_test() ->
 
 loct_stripped_full_module_count_test() ->
   M = load_stripped_module(),
-  redbug_start(?FUNCTION_NAME, "stripped_mod->count", [{time, 999}]),
+  redbug_start(?FUNCTION_NAME, "stripped_mod->count", []),
   M:exported_fun(5),
-  redbug_timeout_stop(),
+  redbug_normal_stop(),
   unload_module(M),
   Content = redbug_output(?FUNCTION_NAME),
   ?assertEqual(<<"stripped_mod:local_fun(5)">>,
@@ -285,9 +243,6 @@ redbug_normal_stop() ->
   redbug:stop(),
   timer:sleep(100).
 
-redbug_timeout_stop() ->
-  timer:sleep(1100).
-
 write_beam(M, Bin) ->
   TmpDir = filename:dirname(code:which(redbug_eunit)),
   TmpFile = filename:join(TmpDir, beam_filename(M)),
@@ -308,22 +263,15 @@ redbug_output(Name) ->
   maybe_delete(Filename),
   Content.
 
-maybe_show(Filename) when is_list(Filename) ->
-  [io:fwrite("~p~n", [read_file(Filename)]) || in_shell()];
 maybe_show(Content) ->
   [io:fwrite("~p~n", [Content]) || in_shell()].
 
-lines(Filename) when is_list(Filename) ->
-  length(read_file(Filename));
 lines(Content) ->
   length(Content).
 
 get_line_seg(Content, Line, Seg) ->
   hd(get_line_seg(Content, Line, Seg, Seg)).
 
--define(is_string(A), A >= 0, A =< 256).
-get_line_seg([A|_] = Filename, Line, SegF, SegL) when ?is_string(A) ->
-  [e(S, e(Line, read_file(Filename))) || S <- lists:seq(SegF, SegL)];
 get_line_seg(Content, Line, SegF, SegL) ->
   [e(S, e(Line, Content)) || S <- lists:seq(SegF, SegL)].
 

--- a/test/redbug_eunit.erl
+++ b/test/redbug_eunit.erl
@@ -19,6 +19,9 @@ millisecond_test_() ->
               maybe_delete(Filename)
       end,
       fun (Content) ->
+              %% Example output:
+              %% % 19:58:26.663 <0.445.0>({erlang,apply,2})
+              %% % lists:sort([3,2,1])
               Timestamp = get_line_seg(Content, 1, 2),
               [?_assertEqual(<<"lists:sort([3,2,1])">>,
                              get_line_seg(Content, 2, 2)),
@@ -40,6 +43,9 @@ arity_test_() ->
               maybe_delete(Filename)
       end,
       fun (Content) ->
+              %% Example output:
+              %% % 19:58:26 <0.445.0>({erlang,apply,2})
+              %% % lists:sort/1
               [?_assertEqual(<<"lists:sort/1">>,
                              get_line_seg(Content, 2, 2)),
                ?_assertEqual(3,
@@ -60,6 +66,9 @@ microsecond_test_() ->
               maybe_delete(Filename)
       end,
       fun (Content) ->
+              %% Example output:
+              %% % 19:58:26.927090 <0.445.0>({erlang,apply,2})
+              %% % lists:sort([3,2,1])
               Timestamp = get_line_seg(Content, 1, 2),
               [?_assertEqual(<<"lists:sort([3,2,1])">>,
                              get_line_seg(Content, 2, 2)),
@@ -81,6 +90,12 @@ buffered_test_() ->
               maybe_delete(Filename)
       end,
       fun (Content) ->
+              %% Example output:
+              %% % 19:58:27 <0.445.0>({erlang,apply,2})
+              %% % lists:sort([3,2,1])
+              %%
+              %% % 19:58:27 <0.445.0>({erlang,apply,2})
+              %% % lists:sort/1 -> [1,2,3]
               [?_assertEqual(<<"lists:sort([3,2,1])">>,
                              get_line_seg(Content, 2, 2)),
                ?_assertEqual([<<"lists:sort/1">>, <<"->">>, <<"[1,2,3]">>],
@@ -101,6 +116,19 @@ return_stack_test_() ->
               maybe_delete(Filename)
       end,
       fun (Content) ->
+              %% Example output:
+              %% % 19:58:27 <0.445.0>({erlang,apply,2})
+              %% % lists:sort([3,2,1])
+              %% %   redbug_eunit:'-return_stack_test_/0-fun-9-'/0
+              %% %   eunit_test:enter_context/4
+              %% %   eunit_proc:run_group/2
+              %% %   eunit_proc:tests_inorder/3
+              %% %   eunit_proc:with_timeout/3
+              %% %   eunit_proc:run_group/2
+              %% %   eunit_proc:tests_inorder/3
+              %% %   eunit_proc:with_timeout/3
+              %% %   eunit_proc:run_group/2
+              %% %   eunit_proc:child_process/2
               Lines = lists:seq(3, lines(Content)-1),
               [?_assertEqual(<<"lists:sort([3,2,1])">>,
                              get_line_seg(Content, 2, 2)),
@@ -123,6 +151,9 @@ proc_send_test_() ->
               maybe_delete(Filename)
       end,
       fun (Content) ->
+              %% Example output:
+              %% % 19:58:27 <0.657.0>(dead)
+              %% % <0.445.0>({erlang,apply,2}) <<< ding
               [?_assertEqual(<<"ding">>,
                              get_line_seg(Content, 2, 4))]
       end}}.
@@ -142,6 +173,9 @@ proc_receive_test_() ->
               maybe_delete(Filename)
       end,
       fun (Content) ->
+              %% Example output:
+              %% % 20:04:32 <0.665.0>({erlang,apply,2})
+              %% % <<< pling
               [?_assertEqual(<<"pling">>,
                              get_line_seg(Content, 2, 3))]
       end}}.
@@ -168,6 +202,10 @@ call_time_test_() ->
               maybe_delete(Filename)
       end,
       fun (Content) ->
+              %% Example output:
+              %% % 19:55:17 <0.445.0>({erlang,apply,2})
+              %% % lists:sort([3,2,1])
+              %% %      1 :      2 :    2.0 : lists:sort/1
               [?_assertEqual(<<"lists:sort([3,2,1])">>,
                              get_line_seg(Content, 2, 2)),
                ?_assertEqual(<<"lists:sort/1">>,
@@ -188,6 +226,11 @@ call_count_test_() ->
               maybe_delete(Filename)
       end,
       fun (Content) ->
+              %% Example output:
+              %% % 20:04:32 <0.445.0>({erlang,apply,2})
+              %% % lists:sort([3,2,1])
+              %%
+              %% %      1 : lists:sort/1
               [?_assertEqual(<<"lists:sort([3,2,1])">>,
                              get_line_seg(Content, 2, 2)),
                ?_assertEqual(<<"lists:sort/1">>,
@@ -206,6 +249,13 @@ blocking_test_() ->
               ok
       end,
       fun (Msgs) ->
+              %% Example output:
+              %% [{call,{{erlang,demonitor,1},<<>>},
+              %%        {<0.445.0>,{erlang,apply,2}},
+              %%        {20,10,36,706682}},
+              %%  {call,{{erlang,monitor,2},<<>>},
+              %%        {<0.445.0>,{erlang,apply,2}},
+              %%        {20,10,36,706695}}]
               [?_assertEqual([{erlang, demonitor, 1},
                               {erlang, monitor, 2}],
                              [MFA || {call, {MFA, _}, _, _} <- Msgs])]
@@ -225,6 +275,9 @@ trace_file_test_() ->
               maybe_delete("foo0.trc")
       end,
       fun (Msgs) ->
+              %% Example output:
+              %% [{trace_ts,<0.445.0>,return_from,{lists,sort,1},[1,2,3],{1778,443837,230786}},
+              %%  {trace_ts,<0.445.0>,call,{lists,sort,[[3,2,1]]},{1778,443837,230776}}]
               [?_assertEqual(sort,
                              e(2, e(4, e(1, Msgs)))),
                ?_assertEqual(sort,
@@ -245,6 +298,12 @@ no_return_test_() ->
               maybe_delete(Filename)
       end,
       fun (Content) ->
+              %% Example output:
+              %% % 20:04:33 <0.445.0>({erlang,apply,2})
+              %% % lists:sort([3,2,1])
+              %%
+              %% % 20:04:33 <0.445.0>({erlang,apply,2})
+              %% % lists:sort/1 -> '...'
               [?_assertEqual(<<"lists:sort([3,2,1])">>,
                              get_line_seg(Content, 2, 2)),
                ?_assertEqual([<<"lists:sort/1">>, <<"->">>, <<"'...'">>],
@@ -265,6 +324,12 @@ improper_list_test_() ->
               maybe_delete(Filename)
       end,
       fun (Content) ->
+              %% Example output:
+              %% % 20:04:33 <0.445.0>({erlang,apply,2})
+              %% % redbug_eunit:ipl()
+              %%
+              %% % 20:04:33 <0.445.0>({erlang,apply,2})
+              %% % redbug_eunit:ipl/0 -> [a,b|c]
               [?_assertEqual(<<"redbug_eunit:ipl()">>,
                              get_line_seg(Content, 2, 2)),
                ?_assertEqual([<<"redbug_eunit:ipl/0">>, <<"->">>, <<"[a,b|c]">>],
@@ -291,6 +356,12 @@ loct_stripped_non_arity_return_test_() ->
               maybe_delete(Filename)
       end,
       fun ({_M, Content}) ->
+              %% Example output:
+              %% % 20:04:33 <0.445.0>({erlang,apply,2})
+              %% % stripped_mod:local_fun(5)
+              %%
+              %% % 20:04:33 <0.445.0>({erlang,apply,2})
+              %% % stripped_mod:local_fun/1 -> 10
               [?_assertEqual(<<"stripped_mod:local_fun(5)">>,
                              get_line_seg(Content, 2, 2)),
                ?_assertEqual([<<"stripped_mod:local_fun/1">>, <<"->">>, <<"10">>],
@@ -314,6 +385,18 @@ loct_stripped_full_module_return_test_() ->
               maybe_delete(Filename)
       end,
       fun ({_M, Content}) ->
+              %% Example output:
+              %% % 20:10:37 <0.445.0>({erlang,apply,2})
+              %% % stripped_mod:exported_fun(5)
+              %%
+              %% % 20:10:37 <0.445.0>({erlang,apply,2})
+              %% % stripped_mod:local_fun(5)
+              %%
+              %% % 20:10:37 <0.445.0>({erlang,apply,2})
+              %% % stripped_mod:local_fun/1 -> 10
+              %%
+              %% % 20:10:37 <0.445.0>({erlang,apply,2})
+              %% % stripped_mod:exported_fun/1 -> 10
               [?_assertEqual(<<"stripped_mod:local_fun(5)">>,
                              get_line_seg(Content, 4, 2)),
                ?_assertEqual([<<"stripped_mod:local_fun/1">>, <<"->">>, <<"10">>],
@@ -337,6 +420,11 @@ loct_stripped_non_arity_count_test_() ->
               maybe_delete(Filename)
       end,
       fun ({_M, Content}) ->
+              %% Example output:
+              %% % 20:10:37 <0.445.0>({erlang,apply,2})
+              %% % stripped_mod:local_fun(5)
+              %%
+              %% %      1 : stripped_mod:local_fun/1
               [?_assertEqual(<<"stripped_mod:local_fun(5)">>,
                              get_line_seg(Content, 2, 2)),
                ?_assertEqual(<<"stripped_mod:local_fun/1">>,
@@ -360,6 +448,16 @@ loct_stripped_full_module_count_test_() ->
               maybe_delete(Filename)
       end,
       fun ({_M, Content}) ->
+              %% Example output:
+              %% % 20:10:38 <0.445.0>({erlang,apply,2})
+              %% % stripped_mod:exported_fun(5)
+              %%
+              %% % 20:10:38 <0.445.0>({erlang,apply,2})
+              %% % stripped_mod:local_fun(5)
+              %%
+              %% %      1 : stripped_mod:local_fun/1
+              %%
+              %% %      1 : stripped_mod:exported_fun/1
               [?_assertEqual(<<"stripped_mod:local_fun(5)">>,
                              get_line_seg(Content, 4, 2)),
                ?_assertEqual(<<"stripped_mod:local_fun/1">>,

--- a/test/redbug_eunit.erl
+++ b/test/redbug_eunit.erl
@@ -6,138 +6,145 @@
 -include_lib("eunit/include/eunit.hrl").
 
 millisecond_test_() ->
-    {setup,
-     fun () ->
-             redbug_start(?FUNCTION_NAME, "lists:sort", [print_msec]),
-             [1, 2, 3] = lists:sort([3, 2, 1]),
-             redbug_normal_stop(),
-             redbug_output(?FUNCTION_NAME)
-     end,
-     fun (_Content) ->
-             Filename = output_filename(?FUNCTION_NAME),
-             maybe_delete(Filename)
-     end,
-     fun (Content) ->
-             Timestamp = get_line_seg(Content, 1, 2),
-             [?_assertEqual(<<"lists:sort([3,2,1])">>,
-                            get_line_seg(Content, 2, 2)),
-              ?_assertEqual({match, [{0,12}, {0,0}, {12,0}]},
-                            re:run(Timestamp, "(.*)[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}(.*)", [{capture, all}]))]
-     end}.
+    {"option `print_msec' produces HH:MM:SS.mmm timestamps",
+     {setup,
+      fun () ->
+              redbug_start(?FUNCTION_NAME, "lists:sort", [print_msec]),
+              [1, 2, 3] = lists:sort([3, 2, 1]),
+              redbug_normal_stop(),
+              redbug_output(?FUNCTION_NAME)
+      end,
+      fun (_Content) ->
+              Filename = output_filename(?FUNCTION_NAME),
+              maybe_delete(Filename)
+      end,
+      fun (Content) ->
+              Timestamp = get_line_seg(Content, 1, 2),
+              [?_assertEqual(<<"lists:sort([3,2,1])">>,
+                             get_line_seg(Content, 2, 2)),
+               ?_assertEqual({match, [{0,12}, {0,0}, {12,0}]},
+                             re:run(Timestamp, "(.*)[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}(.*)", [{capture, all}]))]
+      end}}.
 
 arity_test_() ->
-    {setup,
-     fun () ->
-             redbug_start(?FUNCTION_NAME, "lists:sort", [arity]),
-             [1, 2, 3] = lists:sort([3, 2, 1]),
-             redbug_normal_stop(),
-             redbug_output(?FUNCTION_NAME)
-     end,
-     fun (_Content) ->
-             Filename = output_filename(?FUNCTION_NAME),
-             maybe_delete(Filename)
-     end,
-     fun (Content) ->
-             [?_assertEqual(<<"lists:sort/1">>,
-                            get_line_seg(Content, 2, 2)),
-              ?_assertEqual(3,
-                            length(re:split(get_line_seg(Content, 1, 2), "[:.]")))]
-     end}.
+    {"option `arity' prints function arity instead of arguments",
+     {setup,
+      fun () ->
+              redbug_start(?FUNCTION_NAME, "lists:sort", [arity]),
+              [1, 2, 3] = lists:sort([3, 2, 1]),
+              redbug_normal_stop(),
+              redbug_output(?FUNCTION_NAME)
+      end,
+      fun (_Content) ->
+              Filename = output_filename(?FUNCTION_NAME),
+              maybe_delete(Filename)
+      end,
+      fun (Content) ->
+              [?_assertEqual(<<"lists:sort/1">>,
+                             get_line_seg(Content, 2, 2)),
+               ?_assertEqual(3,
+                             length(re:split(get_line_seg(Content, 1, 2), "[:.]")))]
+      end}}.
 
 microsecond_test_() ->
-    {setup,
-     fun () ->
-             redbug_start(?FUNCTION_NAME, "lists:sort", [{print_time_unit, microsecond}]),
-             [1, 2, 3] = lists:sort([3, 2, 1]),
-             redbug_normal_stop(),
-             redbug_output(?FUNCTION_NAME)
-     end,
-     fun (_Content) ->
-             Filename = output_filename(?FUNCTION_NAME),
-             maybe_delete(Filename)
-     end,
-     fun (Content) ->
-             Timestamp = get_line_seg(Content, 1, 2),
-             [?_assertEqual(<<"lists:sort([3,2,1])">>,
-                            get_line_seg(Content, 2, 2)),
-              ?_assertEqual({match, [{0,15}, {0,0}, {15,0}]},
-                            re:run(Timestamp, "(.*)[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{6}(.*)", [{capture, all}]))]
-     end}.
+    {"option `{print_time_unit, microsecond}' produces HH:MM:SS.mmmmmm timestamps",
+     {setup,
+      fun () ->
+              redbug_start(?FUNCTION_NAME, "lists:sort", [{print_time_unit, microsecond}]),
+              [1, 2, 3] = lists:sort([3, 2, 1]),
+              redbug_normal_stop(),
+              redbug_output(?FUNCTION_NAME)
+      end,
+      fun (_Content) ->
+              Filename = output_filename(?FUNCTION_NAME),
+              maybe_delete(Filename)
+      end,
+      fun (Content) ->
+              Timestamp = get_line_seg(Content, 1, 2),
+              [?_assertEqual(<<"lists:sort([3,2,1])">>,
+                             get_line_seg(Content, 2, 2)),
+               ?_assertEqual({match, [{0,15}, {0,0}, {15,0}]},
+                             re:run(Timestamp, "(.*)[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{6}(.*)", [{capture, all}]))]
+      end}}.
 
 buffered_test_() ->
-    {setup,
-     fun () ->
-             redbug_start(?FUNCTION_NAME, "lists:sort->return", [buffered]),
-             [1, 2, 3] = lists:sort([3, 2, 1]),
-             redbug_normal_stop(),
-             redbug_output(?FUNCTION_NAME)
-     end,
-     fun (_Content) ->
-             Filename = output_filename(?FUNCTION_NAME),
-             maybe_delete(Filename)
-     end,
-     fun (Content) ->
-             [?_assertEqual(<<"lists:sort([3,2,1])">>,
-                            get_line_seg(Content, 2, 2)),
-              ?_assertEqual([<<"lists:sort/1">>, <<"->">>, <<"[1,2,3]">>],
-                            get_line_seg(Content, 4, 2, 4))]
-     end}.
+    {"option `buffered' collects call and return into a single message",
+     {setup,
+      fun () ->
+              redbug_start(?FUNCTION_NAME, "lists:sort->return", [buffered]),
+              [1, 2, 3] = lists:sort([3, 2, 1]),
+              redbug_normal_stop(),
+              redbug_output(?FUNCTION_NAME)
+      end,
+      fun (_Content) ->
+              Filename = output_filename(?FUNCTION_NAME),
+              maybe_delete(Filename)
+      end,
+      fun (Content) ->
+              [?_assertEqual(<<"lists:sort([3,2,1])">>,
+                             get_line_seg(Content, 2, 2)),
+               ?_assertEqual([<<"lists:sort/1">>, <<"->">>, <<"[1,2,3]">>],
+                             get_line_seg(Content, 4, 2, 4))]
+      end}}.
 
 return_stack_test_() ->
-    {setup,
-     fun () ->
-             redbug_start(?FUNCTION_NAME, "lists:sort->stack", []),
-             [1, 2, 3] = lists:sort([3, 2, 1]),
-             redbug_normal_stop(),
-             redbug_output(?FUNCTION_NAME)
-     end,
-     fun (_Content) ->
-             Filename = output_filename(?FUNCTION_NAME),
-             maybe_delete(Filename)
-     end,
-     fun (Content) ->
-             Lines = lists:seq(3, lines(Content)-1),
-             [?_assertEqual(<<"lists:sort([3,2,1])">>,
-                            get_line_seg(Content, 2, 2)),
-              ?_assertEqual([true],
-                            lists:usort([is_mfa(get_line_seg(Content, L, 2))||L<-Lines]))]
-     end}.
+    {"action `stack' prints the call stack",
+     {setup,
+      fun () ->
+              redbug_start(?FUNCTION_NAME, "lists:sort->stack", []),
+              [1, 2, 3] = lists:sort([3, 2, 1]),
+              redbug_normal_stop(),
+              redbug_output(?FUNCTION_NAME)
+      end,
+      fun (_Content) ->
+              Filename = output_filename(?FUNCTION_NAME),
+              maybe_delete(Filename)
+      end,
+      fun (Content) ->
+              Lines = lists:seq(3, lines(Content)-1),
+              [?_assertEqual(<<"lists:sort([3,2,1])">>,
+                             get_line_seg(Content, 2, 2)),
+               ?_assertEqual([true],
+                             lists:usort([is_mfa(get_line_seg(Content, L, 2))||L<-Lines]))]
+      end}}.
 
 proc_send_test_() ->
-    {setup,
-     fun () ->
-             Pid = spawn(fun ding_dong_listener/0),
-             redbug_start(?FUNCTION_NAME, send, [{procs, Pid}]),
-             Pid ! self(),
-             redbug_normal_stop(),
-             redbug_output(?FUNCTION_NAME)
-     end,
-     fun (_Content) ->
-             Filename = output_filename(?FUNCTION_NAME),
-             maybe_delete(Filename)
-     end,
-     fun (Content) ->
-             [?_assertEqual(<<"ding">>,
-                            get_line_seg(Content, 2, 4))]
-     end}.
+    {"trace atom `send' captures messages sent by a process specified by option `procs'",
+     {setup,
+      fun () ->
+              Pid = spawn(fun ding_dong_listener/0),
+              redbug_start(?FUNCTION_NAME, send, [{procs, Pid}]),
+              Pid ! self(),
+              redbug_normal_stop(),
+              redbug_output(?FUNCTION_NAME)
+      end,
+      fun (_Content) ->
+              Filename = output_filename(?FUNCTION_NAME),
+              maybe_delete(Filename)
+      end,
+      fun (Content) ->
+              [?_assertEqual(<<"ding">>,
+                             get_line_seg(Content, 2, 4))]
+      end}}.
 
 proc_receive_test_() ->
-    {setup,
-     fun () ->
-             Pid = spawn(fun ding_dong_listener/0),
-             redbug_start(?FUNCTION_NAME, 'receive', [{procs, Pid}]),
-             Pid ! pling,
-             redbug_normal_stop(),
-             redbug_output(?FUNCTION_NAME)
-     end,
-     fun (_Content) ->
-             Filename = output_filename(?FUNCTION_NAME),
-             maybe_delete(Filename)
-     end,
-     fun (Content) ->
-             [?_assertEqual(<<"pling">>,
-                            get_line_seg(Content, 2, 3))]
-     end}.
+    {"trace atom `receive' captures messages received by a process specified by option `procs'",
+     {setup,
+      fun () ->
+              Pid = spawn(fun ding_dong_listener/0),
+              redbug_start(?FUNCTION_NAME, 'receive', [{procs, Pid}]),
+              Pid ! pling,
+              redbug_normal_stop(),
+              redbug_output(?FUNCTION_NAME)
+      end,
+      fun (_Content) ->
+              Filename = output_filename(?FUNCTION_NAME),
+              maybe_delete(Filename)
+      end,
+      fun (Content) ->
+              [?_assertEqual(<<"pling">>,
+                             get_line_seg(Content, 2, 3))]
+      end}}.
 
 ding_dong_listener()->
     receive
@@ -148,206 +155,216 @@ ding_dong_listener()->
     end.
 
 call_time_test_() ->
-    {setup,
-     fun () ->
-             redbug_start(?FUNCTION_NAME, "lists:sort->time", []),
-             [1, 2, 3] = lists:sort([3, 2, 1]),
-             redbug_normal_stop(),
-             redbug_output(?FUNCTION_NAME)
-     end,
-     fun (_Content) ->
-             Filename = output_filename(?FUNCTION_NAME),
-             maybe_delete(Filename)
-     end,
-     fun (Content) ->
-             [?_assertEqual(<<"lists:sort([3,2,1])">>,
-                            get_line_seg(Content, 2, 2)),
-              ?_assertEqual(<<"lists:sort/1">>,
-                            get_line_seg(Content, 3, 8))]
-     end}.
+    {"action `time' reports the call duration",
+     {setup,
+      fun () ->
+              redbug_start(?FUNCTION_NAME, "lists:sort->time", []),
+              [1, 2, 3] = lists:sort([3, 2, 1]),
+              redbug_normal_stop(),
+              redbug_output(?FUNCTION_NAME)
+      end,
+      fun (_Content) ->
+              Filename = output_filename(?FUNCTION_NAME),
+              maybe_delete(Filename)
+      end,
+      fun (Content) ->
+              [?_assertEqual(<<"lists:sort([3,2,1])">>,
+                             get_line_seg(Content, 2, 2)),
+               ?_assertEqual(<<"lists:sort/1">>,
+                             get_line_seg(Content, 3, 8))]
+      end}}.
 
 call_count_test_() ->
-    {setup,
-     fun () ->
-             redbug_start(?FUNCTION_NAME, "lists:sort->count", []),
-             [1, 2, 3] = lists:sort([3, 2, 1]),
-             redbug_normal_stop(),
-             redbug_output(?FUNCTION_NAME)
-     end,
-     fun (_Content) ->
-             Filename = output_filename(?FUNCTION_NAME),
-             maybe_delete(Filename)
-     end,
-     fun (Content) ->
-             [?_assertEqual(<<"lists:sort([3,2,1])">>,
-                            get_line_seg(Content, 2, 2)),
-              ?_assertEqual(<<"lists:sort/1">>,
-                            get_line_seg(Content, 3, 4))]
-     end}.
+    {"action `count' reports the number of calls",
+     {setup,
+      fun () ->
+              redbug_start(?FUNCTION_NAME, "lists:sort->count", []),
+              [1, 2, 3] = lists:sort([3, 2, 1]),
+              redbug_normal_stop(),
+              redbug_output(?FUNCTION_NAME)
+      end,
+      fun (_Content) ->
+              Filename = output_filename(?FUNCTION_NAME),
+              maybe_delete(Filename)
+      end,
+      fun (Content) ->
+              [?_assertEqual(<<"lists:sort([3,2,1])">>,
+                             get_line_seg(Content, 2, 2)),
+               ?_assertEqual(<<"lists:sort/1">>,
+                             get_line_seg(Content, 3, 4))]
+      end}}.
 
 blocking_test_() ->
-    {setup,
-     fun () ->
-             Options = [blocking, arity, {time, 499}, debug],
-             {timeout, Msgs} = redbug:start(["erlang:demonitor", "erlang:monitor"], Options),
-             Msgs
-     end,
-     fun (_Msgs) ->
-             ok
-     end,
-     fun (Msgs) ->
-             [?_assertEqual([{erlang, demonitor, 1},
-                             {erlang, monitor, 2}],
-                            [MFA || {call, {MFA, _}, _, _} <- Msgs])]
-     end}.
+    {"option `blocking' returns trace results synchronously",
+     {setup,
+      fun () ->
+              Options = [blocking, arity, {time, 499}, debug],
+              {timeout, Msgs} = redbug:start(["erlang:demonitor", "erlang:monitor"], Options),
+              Msgs
+      end,
+      fun (_Msgs) ->
+              ok
+      end,
+      fun (Msgs) ->
+              [?_assertEqual([{erlang, demonitor, 1},
+                              {erlang, monitor, 2}],
+                             [MFA || {call, {MFA, _}, _, _} <- Msgs])]
+      end}}.
 
 trace_file_test_() ->
-    {setup,
-     fun () ->
-             redbug_start(?FUNCTION_NAME, "lists:sort->return", [{file, "foo"}]),
-             [1, 2, 3] = lists:sort([3, 2, 1]),
-             redbug_normal_stop(),
-             {2, Msgs} = replay_trc:go("foo0.trc", fun(E, A) -> [E]++A end, []),
-             Msgs
-     end,
-     fun (_Msgs) ->
-             maybe_delete("foo0.trc")
-     end,
-     fun (Msgs) ->
-             [?_assertEqual(sort,
-                            e(2, e(4, e(1, Msgs)))),
-              ?_assertEqual(sort,
-                            e(2, e(4, e(2, Msgs))))]
-     end}.
+    {"option `file' writes trace files",
+     {setup,
+      fun () ->
+              redbug_start(?FUNCTION_NAME, "lists:sort->return", [{file, "foo"}]),
+              [1, 2, 3] = lists:sort([3, 2, 1]),
+              redbug_normal_stop(),
+              {2, Msgs} = replay_trc:go("foo0.trc", fun(E, A) -> [E]++A end, []),
+              Msgs
+      end,
+      fun (_Msgs) ->
+              maybe_delete("foo0.trc")
+      end,
+      fun (Msgs) ->
+              [?_assertEqual(sort,
+                             e(2, e(4, e(1, Msgs)))),
+               ?_assertEqual(sort,
+                             e(2, e(4, e(2, Msgs))))]
+      end}}.
 
 no_return_test_() ->
-    {setup,
-     fun () ->
-             redbug_start(?FUNCTION_NAME, "lists:sort->return", [{print_return, false}]),
-             [1, 2, 3] = lists:sort([3, 2, 1]),
-             redbug_normal_stop(),
-             redbug_output(?FUNCTION_NAME)
-     end,
-     fun (_Content) ->
-             Filename = output_filename(?FUNCTION_NAME),
-             maybe_delete(Filename)
-     end,
-     fun (Content) ->
-             [?_assertEqual(<<"lists:sort([3,2,1])">>,
-                            get_line_seg(Content, 2, 2)),
-              ?_assertEqual([<<"lists:sort/1">>, <<"->">>, <<"'...'">>],
-                            get_line_seg(Content, 4, 2, 4))]
-     end}.
+    {"option `{print_return, false}' suppresses the return value",
+     {setup,
+      fun () ->
+              redbug_start(?FUNCTION_NAME, "lists:sort->return", [{print_return, false}]),
+              [1, 2, 3] = lists:sort([3, 2, 1]),
+              redbug_normal_stop(),
+              redbug_output(?FUNCTION_NAME)
+      end,
+      fun (_Content) ->
+              Filename = output_filename(?FUNCTION_NAME),
+              maybe_delete(Filename)
+      end,
+      fun (Content) ->
+              [?_assertEqual(<<"lists:sort([3,2,1])">>,
+                             get_line_seg(Content, 2, 2)),
+               ?_assertEqual([<<"lists:sort/1">>, <<"->">>, <<"'...'">>],
+                             get_line_seg(Content, 4, 2, 4))]
+      end}}.
 
 improper_list_test_() ->
-    {setup,
-     fun () ->
-             redbug_start(?FUNCTION_NAME, "redbug_eunit:ipl()->return", []),
-             ipl(),
-             redbug_normal_stop(),
-             redbug_output(?FUNCTION_NAME)
-     end,
-     fun (_Content) ->
-             Filename = output_filename(?FUNCTION_NAME),
-             maybe_delete(Filename)
-     end,
-     fun (Content) ->
-             [?_assertEqual(<<"redbug_eunit:ipl()">>,
-                            get_line_seg(Content, 2, 2)),
-              ?_assertEqual([<<"redbug_eunit:ipl/0">>, <<"->">>, <<"[a,b|c]">>],
-                            get_line_seg(Content, 4, 2, 4))]
-     end}.
+    {"improper lists are properly output",
+     {setup,
+      fun () ->
+              redbug_start(?FUNCTION_NAME, "redbug_eunit:ipl()->return", []),
+              ipl(),
+              redbug_normal_stop(),
+              redbug_output(?FUNCTION_NAME)
+      end,
+      fun (_Content) ->
+              Filename = output_filename(?FUNCTION_NAME),
+              maybe_delete(Filename)
+      end,
+      fun (Content) ->
+              [?_assertEqual(<<"redbug_eunit:ipl()">>,
+                             get_line_seg(Content, 2, 2)),
+               ?_assertEqual([<<"redbug_eunit:ipl/0">>, <<"->">>, <<"[a,b|c]">>],
+                             get_line_seg(Content, 4, 2, 4))]
+      end}}.
 
 %% test printing of improper lists
 ipl() -> [a, b|c].
 
 loct_stripped_non_arity_return_test_() ->
-    {setup,
-     fun () ->
-             M = load_stripped_module(),
-             redbug_start(?FUNCTION_NAME, "stripped_mod:local_fun->return", []),
-             M:exported_fun(5),
-             redbug_normal_stop(),
-             Content = redbug_output(?FUNCTION_NAME),
-             {M, Content}
-     end,
-     fun ({M, _Content}) ->
-             unload_module(M),
-             Filename = output_filename(?FUNCTION_NAME),
-             maybe_delete(Filename)
-     end,
-     fun ({_M, Content}) ->
-             [?_assertEqual(<<"stripped_mod:local_fun(5)">>,
-                            get_line_seg(Content, 2, 2)),
-              ?_assertEqual([<<"stripped_mod:local_fun/1">>, <<"->">>, <<"10">>],
-                            get_line_seg(Content, 4, 2, 4))]
-     end}.
+    {"tracing a non-exported function with action `return' works when LocT is stripped",
+     {setup,
+      fun () ->
+              M = load_stripped_module(),
+              redbug_start(?FUNCTION_NAME, "stripped_mod:local_fun->return", []),
+              M:exported_fun(5),
+              redbug_normal_stop(),
+              Content = redbug_output(?FUNCTION_NAME),
+              {M, Content}
+      end,
+      fun ({M, _Content}) ->
+              unload_module(M),
+              Filename = output_filename(?FUNCTION_NAME),
+              maybe_delete(Filename)
+      end,
+      fun ({_M, Content}) ->
+              [?_assertEqual(<<"stripped_mod:local_fun(5)">>,
+                             get_line_seg(Content, 2, 2)),
+               ?_assertEqual([<<"stripped_mod:local_fun/1">>, <<"->">>, <<"10">>],
+                             get_line_seg(Content, 4, 2, 4))]
+      end}}.
 
 loct_stripped_full_module_return_test_() ->
-    {setup,
-     fun () ->
-             M = load_stripped_module(),
-             redbug_start(?FUNCTION_NAME, "stripped_mod->return", []),
-             M:exported_fun(5),
-             redbug_normal_stop(),
-             Content = redbug_output(?FUNCTION_NAME),
-             {M, Content}
-     end,
-     fun ({M, _Content}) ->
-             unload_module(M),
-             Filename = output_filename(?FUNCTION_NAME),
-             maybe_delete(Filename)
-     end,
-     fun ({_M, Content}) ->
-             [?_assertEqual(<<"stripped_mod:local_fun(5)">>,
-                            get_line_seg(Content, 4, 2)),
-              ?_assertEqual([<<"stripped_mod:local_fun/1">>, <<"->">>, <<"10">>],
-                            get_line_seg(Content, 6, 2, 4))]
-     end}.
+    {"tracing a full module with action `return' works when LocT is stripped",
+     {setup,
+      fun () ->
+              M = load_stripped_module(),
+              redbug_start(?FUNCTION_NAME, "stripped_mod->return", []),
+              M:exported_fun(5),
+              redbug_normal_stop(),
+              Content = redbug_output(?FUNCTION_NAME),
+              {M, Content}
+      end,
+      fun ({M, _Content}) ->
+              unload_module(M),
+              Filename = output_filename(?FUNCTION_NAME),
+              maybe_delete(Filename)
+      end,
+      fun ({_M, Content}) ->
+              [?_assertEqual(<<"stripped_mod:local_fun(5)">>,
+                             get_line_seg(Content, 4, 2)),
+               ?_assertEqual([<<"stripped_mod:local_fun/1">>, <<"->">>, <<"10">>],
+                             get_line_seg(Content, 6, 2, 4))]
+      end}}.
 
 loct_stripped_non_arity_count_test_() ->
-    {setup,
-     fun () ->
-             M = load_stripped_module(),
-             redbug_start(?FUNCTION_NAME, "stripped_mod:local_fun->count", []),
-             M:exported_fun(5),
-             redbug_normal_stop(),
-             Content = redbug_output(?FUNCTION_NAME),
-             {M, Content}
-     end,
-     fun ({M, _Content}) ->
-             unload_module(M),
-             Filename = output_filename(?FUNCTION_NAME),
-             maybe_delete(Filename)
-     end,
-     fun ({_M, Content}) ->
-             [?_assertEqual(<<"stripped_mod:local_fun(5)">>,
-                            get_line_seg(Content, 2, 2)),
-              ?_assertEqual(<<"stripped_mod:local_fun/1">>,
-                            get_line_seg(Content, 3, 4))]
-     end}.
+    {"tracing a non-exported function with action count works when LocT is stripped",
+     {setup,
+      fun () ->
+              M = load_stripped_module(),
+              redbug_start(?FUNCTION_NAME, "stripped_mod:local_fun->count", []),
+              M:exported_fun(5),
+              redbug_normal_stop(),
+              Content = redbug_output(?FUNCTION_NAME),
+              {M, Content}
+      end,
+      fun ({M, _Content}) ->
+              unload_module(M),
+              Filename = output_filename(?FUNCTION_NAME),
+              maybe_delete(Filename)
+      end,
+      fun ({_M, Content}) ->
+              [?_assertEqual(<<"stripped_mod:local_fun(5)">>,
+                             get_line_seg(Content, 2, 2)),
+               ?_assertEqual(<<"stripped_mod:local_fun/1">>,
+                             get_line_seg(Content, 3, 4))]
+      end}}.
 
 loct_stripped_full_module_count_test_() ->
-    {setup,
-     fun () ->
-             M = load_stripped_module(),
-             redbug_start(?FUNCTION_NAME, "stripped_mod->count", []),
-             M:exported_fun(5),
-             redbug_normal_stop(),
-             Content = redbug_output(?FUNCTION_NAME),
-             {M, Content}
-     end,
-     fun ({M, _}) ->
-             unload_module(M),
-             Filename = output_filename(?FUNCTION_NAME),
-             maybe_delete(Filename)
-     end,
-     fun ({_M, Content}) ->
-             [?_assertEqual(<<"stripped_mod:local_fun(5)">>,
-                            get_line_seg(Content, 4, 2)),
-              ?_assertEqual(<<"stripped_mod:local_fun/1">>,
-                            get_line_seg(Content, 5, 4))]
-     end}.
+    {"tracing a full module with action `count' works when LocT is stripped",
+     {setup,
+      fun () ->
+              M = load_stripped_module(),
+              redbug_start(?FUNCTION_NAME, "stripped_mod->count", []),
+              M:exported_fun(5),
+              redbug_normal_stop(),
+              Content = redbug_output(?FUNCTION_NAME),
+              {M, Content}
+      end,
+      fun ({M, _}) ->
+              unload_module(M),
+              Filename = output_filename(?FUNCTION_NAME),
+              maybe_delete(Filename)
+      end,
+      fun ({_M, Content}) ->
+              [?_assertEqual(<<"stripped_mod:local_fun(5)">>,
+                             get_line_seg(Content, 4, 2)),
+               ?_assertEqual(<<"stripped_mod:local_fun/1">>,
+                             get_line_seg(Content, 5, 4))]
+      end}}.
 
 load_stripped_module() ->
     TestCode =

--- a/test/redbug_eunit.erl
+++ b/test/redbug_eunit.erl
@@ -5,185 +5,345 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-millisecond_test() ->
-  redbug_start(?FUNCTION_NAME, "lists:sort", [print_msec]),
-  [1, 2, 3] = lists:sort([3, 2, 1]),
-  redbug_normal_stop(),
-  Content = redbug_output(?FUNCTION_NAME),
-  Timestamp = get_line_seg(Content, 1, 2),
-  Re = re:run(Timestamp, "(.*)[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}(.*)", [{capture, all}]),
-  ?assertEqual(<<"lists:sort([3,2,1])">>,
-               get_line_seg(Content, 2, 2)),
-  ?assertEqual({match, [{0,12}, {0,0}, {12,0}]}, Re).
+millisecond_test_() ->
+  {setup,
+   fun () ->
+           redbug_start(?FUNCTION_NAME, "lists:sort", [print_msec]),
+           [1, 2, 3] = lists:sort([3, 2, 1]),
+           redbug_normal_stop(),
+           redbug_output(?FUNCTION_NAME)
+   end,
+   fun (_Content) ->
+           Filename = output_filename(?FUNCTION_NAME),
+           maybe_delete(Filename)
+   end,
+   fun (Content) ->
+           Timestamp = get_line_seg(Content, 1, 2),
+           [?_assertEqual(<<"lists:sort([3,2,1])">>,
+                          get_line_seg(Content, 2, 2)),
+            ?_assertEqual({match, [{0,12}, {0,0}, {12,0}]},
+                          re:run(Timestamp, "(.*)[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}(.*)", [{capture, all}]))]
+   end}.
 
-arity_test() ->
-  redbug_start(?FUNCTION_NAME, "lists:sort", [arity]),
-  [1, 2, 3] = lists:sort([3, 2, 1]),
-  redbug_normal_stop(),
-  Content = redbug_output(?FUNCTION_NAME),
-  ?assertEqual(<<"lists:sort/1">>,
-               get_line_seg(Content, 2, 2)),
-  ?assertEqual(3,
-               length(re:split(get_line_seg(Content, 1, 2), "[:.]"))).
+arity_test_() ->
+  {setup,
+   fun () ->
+           redbug_start(?FUNCTION_NAME, "lists:sort", [arity]),
+           [1, 2, 3] = lists:sort([3, 2, 1]),
+           redbug_normal_stop(),
+           redbug_output(?FUNCTION_NAME)
+   end,
+   fun (_Content) ->
+           Filename = output_filename(?FUNCTION_NAME),
+           maybe_delete(Filename)
+   end,
+   fun (Content) ->
+           [?_assertEqual(<<"lists:sort/1">>,
+                          get_line_seg(Content, 2, 2)),
+            ?_assertEqual(3,
+                          length(re:split(get_line_seg(Content, 1, 2), "[:.]")))]
+   end}.
 
-microsecond_test() ->
-  redbug_start(?FUNCTION_NAME, "lists:sort", [{print_time_unit, microsecond}]),
-  [1, 2, 3] = lists:sort([3, 2, 1]),
-  redbug_normal_stop(),
-  Content = redbug_output(?FUNCTION_NAME),
-  Timestamp = get_line_seg(Content, 1, 2),
-  Re = re:run(Timestamp, "(.*)[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{6}(.*)", [{capture, all}]),
-  ?assertEqual(<<"lists:sort([3,2,1])">>,
-               get_line_seg(Content, 2, 2)),
-  ?assertEqual({match, [{0,15}, {0,0}, {15,0}]}, Re).
+microsecond_test_() ->
+  {setup,
+   fun () ->
+           redbug_start(?FUNCTION_NAME, "lists:sort", [{print_time_unit, microsecond}]),
+           [1, 2, 3] = lists:sort([3, 2, 1]),
+           redbug_normal_stop(),
+           redbug_output(?FUNCTION_NAME)
+   end,
+   fun (_Content) ->
+           Filename = output_filename(?FUNCTION_NAME),
+           maybe_delete(Filename)
+   end,
+   fun (Content) ->
+           Timestamp = get_line_seg(Content, 1, 2),
+           [?_assertEqual(<<"lists:sort([3,2,1])">>,
+                          get_line_seg(Content, 2, 2)),
+            ?_assertEqual({match, [{0,15}, {0,0}, {15,0}]},
+                          re:run(Timestamp, "(.*)[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{6}(.*)", [{capture, all}]))]
+   end}.
 
-buffered_test() ->
-  redbug_start(?FUNCTION_NAME, "lists:sort->return", [buffered]),
-  [1, 2, 3] = lists:sort([3, 2, 1]),
-  redbug_normal_stop(),
-  Content = redbug_output(?FUNCTION_NAME),
-  ?assertEqual(<<"lists:sort([3,2,1])">>,
-               get_line_seg(Content, 2, 2)),
-  ?assertEqual([<<"lists:sort/1">>, <<"->">>, <<"[1,2,3]">>],
-               get_line_seg(Content, 4, 2, 4)).
+buffered_test_() ->
+    {setup,
+     fun () ->
+             redbug_start(?FUNCTION_NAME, "lists:sort->return", [buffered]),
+             [1, 2, 3] = lists:sort([3, 2, 1]),
+             redbug_normal_stop(),
+             redbug_output(?FUNCTION_NAME)
+     end,
+     fun (_Content) ->
+             Filename = output_filename(?FUNCTION_NAME),
+             maybe_delete(Filename)
+     end,
+     fun (Content) ->
+             [?_assertEqual(<<"lists:sort([3,2,1])">>,
+                            get_line_seg(Content, 2, 2)),
+              ?_assertEqual([<<"lists:sort/1">>, <<"->">>, <<"[1,2,3]">>],
+                            get_line_seg(Content, 4, 2, 4))]
+     end}.
 
-return_stack_test() ->
-  redbug_start(?FUNCTION_NAME, "lists:sort->stack", []),
-  [1, 2, 3] = lists:sort([3, 2, 1]),
-  redbug_normal_stop(),
-  Content = redbug_output(?FUNCTION_NAME),
-  ?assertEqual(<<"lists:sort([3,2,1])">>,
-               get_line_seg(Content, 2, 2)),
-  Lines = lists:seq(3, lines(Content)-1),
-  ?assertEqual([true],
-               lists:usort([is_mfa(get_line_seg(Content, L, 2))||L<-Lines])).
+return_stack_test_() ->
+    {setup,
+     fun () ->
+             redbug_start(?FUNCTION_NAME, "lists:sort->stack", []),
+             [1, 2, 3] = lists:sort([3, 2, 1]),
+             redbug_normal_stop(),
+             redbug_output(?FUNCTION_NAME)
+     end,
+     fun (_Content) ->
+             Filename = output_filename(?FUNCTION_NAME),
+             maybe_delete(Filename)
+     end,
+     fun (Content) ->
+             Lines = lists:seq(3, lines(Content)-1),
+             [?_assertEqual(<<"lists:sort([3,2,1])">>,
+                            get_line_seg(Content, 2, 2)),
+              ?_assertEqual([true],
+                            lists:usort([is_mfa(get_line_seg(Content, L, 2))||L<-Lines]))]
+     end}.
 
-proc_send_test() ->
-  Pid = spawn(fun()->receive P when is_pid(P)->P!ding; quit->ok; after 1500 -> timeout end end),
-  redbug_start(?FUNCTION_NAME, send, [{procs, Pid}]),
-  Pid ! self(),
-  redbug_normal_stop(),
-  Content = redbug_output(?FUNCTION_NAME),
-  ?assertEqual(<<"ding">>,
-               get_line_seg(Content, 2, 4)).
+proc_send_test_() ->
+    {setup,
+     fun () ->
+             Pid = spawn(fun ding_dong_listener/0),
+             redbug_start(?FUNCTION_NAME, send, [{procs, Pid}]),
+             Pid ! self(),
+             redbug_normal_stop(),
+             redbug_output(?FUNCTION_NAME)
+     end,
+     fun (_Content) ->
+             Filename = output_filename(?FUNCTION_NAME),
+             maybe_delete(Filename)
+     end,
+     fun (Content) ->
+             [?_assertEqual(<<"ding">>,
+                            get_line_seg(Content, 2, 4))]
+     end}.
 
-proc_receive_test() ->
-  Pid = spawn(fun()->receive P when is_pid(P)->P!ding; quit->ok; after 1500 -> timeout end end),
-  redbug_start(?FUNCTION_NAME, 'receive', [{procs, Pid}]),
-  Pid ! pling,
-  redbug_normal_stop(),
-  Content = redbug_output(?FUNCTION_NAME),
-  ?assertEqual(<<"pling">>,
-               get_line_seg(Content, 2, 3)).
+proc_receive_test_() ->
+    {setup,
+     fun () ->
+             Pid = spawn(fun ding_dong_listener/0),
+             redbug_start(?FUNCTION_NAME, 'receive', [{procs, Pid}]),
+             Pid ! pling,
+             redbug_normal_stop(),
+             redbug_output(?FUNCTION_NAME)
+     end,
+     fun (_Content) ->
+             Filename = output_filename(?FUNCTION_NAME),
+             maybe_delete(Filename)
+     end,
+     fun (Content) ->
+             [?_assertEqual(<<"pling">>,
+                            get_line_seg(Content, 2, 3))]
+     end}.
 
-call_time_test() ->
-  redbug_start(?FUNCTION_NAME, "lists:sort->time", []),
-  [1, 2, 3] = lists:sort([3, 2, 1]),
-  redbug_normal_stop(),
-  Content = redbug_output(?FUNCTION_NAME),
-  ?assertEqual(<<"lists:sort([3,2,1])">>,
-               get_line_seg(Content, 2, 2)),
-  ?assertEqual(<<"lists:sort/1">>,
-               get_line_seg(Content, 3, 8)).
+ding_dong_listener()->
+  receive
+      P when is_pid(P) -> P ! ding;
+      quit -> ok
+  after
+      1500 -> timeout
+  end.
 
-call_count_test() ->
-  redbug_start(?FUNCTION_NAME, "lists:sort->count", []),
-  [1, 2, 3] = lists:sort([3, 2, 1]),
-  redbug_normal_stop(),
-  Content = redbug_output(?FUNCTION_NAME),
-  ?assertEqual(<<"lists:sort([3,2,1])">>,
-               get_line_seg(Content, 2, 2)),
-  ?assertEqual(<<"lists:sort/1">>,
-               get_line_seg(Content, 3, 4)).
+call_time_test_() ->
+    {setup,
+     fun () ->
+             redbug_start(?FUNCTION_NAME, "lists:sort->time", []),
+             [1, 2, 3] = lists:sort([3, 2, 1]),
+             redbug_normal_stop(),
+             redbug_output(?FUNCTION_NAME)
+     end,
+     fun (_Content) ->
+             Filename = output_filename(?FUNCTION_NAME),
+             maybe_delete(Filename)
+     end,
+     fun (Content) ->
+             [?_assertEqual(<<"lists:sort([3,2,1])">>,
+                            get_line_seg(Content, 2, 2)),
+              ?_assertEqual(<<"lists:sort/1">>,
+                            get_line_seg(Content, 3, 8))]
+     end}.
 
-blocking_test() ->
-  Options = [blocking, arity, {time, 499}, debug],
-  {timeout, Msgs} = redbug:start(["erlang:demonitor", "erlang:monitor"], Options),
-  ?assertEqual([{erlang, demonitor, 1},
-                {erlang, monitor, 2}],
-               [MFA || {call, {MFA, _}, _, _} <- Msgs]).
+call_count_test_() ->
+    {setup,
+     fun () ->
+             redbug_start(?FUNCTION_NAME, "lists:sort->count", []),
+             [1, 2, 3] = lists:sort([3, 2, 1]),
+             redbug_normal_stop(),
+             redbug_output(?FUNCTION_NAME)
+     end,
+     fun (_Content) ->
+             Filename = output_filename(?FUNCTION_NAME),
+             maybe_delete(Filename)
+     end,
+     fun (Content) ->
+             [?_assertEqual(<<"lists:sort([3,2,1])">>,
+                            get_line_seg(Content, 2, 2)),
+              ?_assertEqual(<<"lists:sort/1">>,
+                            get_line_seg(Content, 3, 4))]
+     end}.
 
-trace_file_test() ->
-  redbug_start(?FUNCTION_NAME, "lists:sort->return", [{file, "foo"}]),
-  [1, 2, 3] = lists:sort([3, 2, 1]),
-  redbug_normal_stop(),
-  {2, Msgs} = replay_trc:go("foo0.trc", fun(E, A) -> [E]++A end, []),
-  maybe_delete("foo0.trc"),
-  ?assertEqual(sort,
-               e(2, e(4, e(1, Msgs)))),
-  ?assertEqual(sort,
-               e(2, e(4, e(2, Msgs)))).
+blocking_test_() ->
+    {setup,
+     fun () ->
+             Options = [blocking, arity, {time, 499}, debug],
+             {timeout, Msgs} = redbug:start(["erlang:demonitor", "erlang:monitor"], Options),
+             Msgs
+     end,
+     fun (_Msgs) ->
+             ok
+     end,
+     fun (Msgs) ->
+             [?_assertEqual([{erlang, demonitor, 1},
+                             {erlang, monitor, 2}],
+                            [MFA || {call, {MFA, _}, _, _} <- Msgs])]
+     end}.
 
-no_return_test() ->
-  redbug_start(?FUNCTION_NAME, "lists:sort->return", [{print_return, false}]),
-  [1, 2, 3] = lists:sort([3, 2, 1]),
-  redbug_normal_stop(),
-  Content = redbug_output(?FUNCTION_NAME),
-  ?assertEqual(<<"lists:sort([3,2,1])">>,
-               get_line_seg(Content, 2, 2)),
-  ?assertEqual([<<"lists:sort/1">>, <<"->">>, <<"'...'">>],
-               get_line_seg(Content, 4, 2, 4)).
+trace_file_test_() ->
+    {setup,
+     fun () ->
+             redbug_start(?FUNCTION_NAME, "lists:sort->return", [{file, "foo"}]),
+             [1, 2, 3] = lists:sort([3, 2, 1]),
+             redbug_normal_stop(),
+             {2, Msgs} = replay_trc:go("foo0.trc", fun(E, A) -> [E]++A end, []),
+             Msgs
+     end,
+     fun (_Msgs) ->
+             maybe_delete("foo0.trc")
+     end,
+     fun (Msgs) ->
+             [?_assertEqual(sort,
+                            e(2, e(4, e(1, Msgs)))),
+              ?_assertEqual(sort,
+                            e(2, e(4, e(2, Msgs))))]
+     end}.
 
-improper_list_test() ->
-  redbug_start(?FUNCTION_NAME, "redbug_eunit:ipl()->return", []),
-  ipl(),
-  redbug_normal_stop(),
-  Content = redbug_output(?FUNCTION_NAME),
-  ?assertEqual(<<"redbug_eunit:ipl()">>,
-               get_line_seg(Content, 2, 2)),
-  ?assertEqual([<<"redbug_eunit:ipl/0">>, <<"->">>, <<"[a,b|c]">>],
-               get_line_seg(Content, 4, 2, 4)).
+no_return_test_() ->
+    {setup,
+     fun () ->
+             redbug_start(?FUNCTION_NAME, "lists:sort->return", [{print_return, false}]),
+             [1, 2, 3] = lists:sort([3, 2, 1]),
+             redbug_normal_stop(),
+             redbug_output(?FUNCTION_NAME)
+     end,
+     fun (_Content) ->
+             Filename = output_filename(?FUNCTION_NAME),
+             maybe_delete(Filename)
+     end,
+     fun (Content) ->
+             [?_assertEqual(<<"lists:sort([3,2,1])">>,
+                            get_line_seg(Content, 2, 2)),
+              ?_assertEqual([<<"lists:sort/1">>, <<"->">>, <<"'...'">>],
+                            get_line_seg(Content, 4, 2, 4))]
+     end}.
+
+improper_list_test_() ->
+    {setup,
+     fun () ->
+             redbug_start(?FUNCTION_NAME, "redbug_eunit:ipl()->return", []),
+             ipl(),
+             redbug_normal_stop(),
+             redbug_output(?FUNCTION_NAME)
+     end,
+     fun (_Content) ->
+             Filename = output_filename(?FUNCTION_NAME),
+             maybe_delete(Filename)
+     end,
+     fun (Content) ->
+             [?_assertEqual(<<"redbug_eunit:ipl()">>,
+                            get_line_seg(Content, 2, 2)),
+              ?_assertEqual([<<"redbug_eunit:ipl/0">>, <<"->">>, <<"[a,b|c]">>],
+                            get_line_seg(Content, 4, 2, 4))]
+     end}.
 
 %% test printing of improper lists
 ipl() -> [a, b|c].
 
-loct_stripped_non_arity_return_test() ->
-  M = load_stripped_module(),
-  redbug_start(?FUNCTION_NAME, "stripped_mod:local_fun->return", []),
-  M:exported_fun(5),
-  redbug_normal_stop(),
-  unload_module(M),
-  Content = redbug_output(?FUNCTION_NAME),
-  ?assertEqual(<<"stripped_mod:local_fun(5)">>,
-               get_line_seg(Content, 2, 2)),
-  ?assertEqual([<<"stripped_mod:local_fun/1">>, <<"->">>, <<"10">>],
-               get_line_seg(Content, 4, 2, 4)).
+loct_stripped_non_arity_return_test_() ->
+    {setup,
+     fun () ->
+             M = load_stripped_module(),
+             redbug_start(?FUNCTION_NAME, "stripped_mod:local_fun->return", []),
+             M:exported_fun(5),
+             redbug_normal_stop(),
+             unload_module(M),
+             redbug_output(?FUNCTION_NAME)
+     end,
+     fun (_Content) ->
+             Filename = output_filename(?FUNCTION_NAME),
+             maybe_delete(Filename)
+     end,
+     fun (Content) ->
+             [?_assertEqual(<<"stripped_mod:local_fun(5)">>,
+                            get_line_seg(Content, 2, 2)),
+              ?_assertEqual([<<"stripped_mod:local_fun/1">>, <<"->">>, <<"10">>],
+                            get_line_seg(Content, 4, 2, 4))]
+     end}.
 
-loct_stripped_full_module_return_test() ->
-  M = load_stripped_module(),
-  redbug_start(?FUNCTION_NAME, "stripped_mod->return", []),
-  M:exported_fun(5),
-  redbug_normal_stop(),
-  unload_module(M),
-  Content = redbug_output(?FUNCTION_NAME),
-  ?assertEqual(<<"stripped_mod:local_fun(5)">>,
-               get_line_seg(Content, 4, 2)),
-  ?assertEqual([<<"stripped_mod:local_fun/1">>, <<"->">>, <<"10">>],
-               get_line_seg(Content, 6, 2, 4)).
+loct_stripped_full_module_return_test_() ->
+    {setup,
+     fun () ->
+             M = load_stripped_module(),
+             redbug_start(?FUNCTION_NAME, "stripped_mod->return", []),
+             M:exported_fun(5),
+             redbug_normal_stop(),
+             unload_module(M),
+             redbug_output(?FUNCTION_NAME)
+     end,
+     fun (_Content) ->
+             Filename = output_filename(?FUNCTION_NAME),
+             maybe_delete(Filename)
+     end,
+     fun (Content) ->
+             [?_assertEqual(<<"stripped_mod:local_fun(5)">>,
+                            get_line_seg(Content, 4, 2)),
+              ?_assertEqual([<<"stripped_mod:local_fun/1">>, <<"->">>, <<"10">>],
+                            get_line_seg(Content, 6, 2, 4))]
+     end}.
 
-loct_stripped_non_arity_count_test() ->
-  M = load_stripped_module(),
-  redbug_start(?FUNCTION_NAME, "stripped_mod:local_fun->count", []),
-  M:exported_fun(5),
-  redbug_normal_stop(),
-  unload_module(M),
-  Content = redbug_output(?FUNCTION_NAME),
-  ?assertEqual(<<"stripped_mod:local_fun(5)">>,
-               get_line_seg(Content, 2, 2)),
-  ?assertEqual(<<"stripped_mod:local_fun/1">>,
-               get_line_seg(Content, 3, 4)).
+loct_stripped_non_arity_count_test_() ->
+    {setup,
+     fun () ->
+             M = load_stripped_module(),
+             redbug_start(?FUNCTION_NAME, "stripped_mod:local_fun->count", []),
+             M:exported_fun(5),
+             redbug_normal_stop(),
+             unload_module(M),
+             redbug_output(?FUNCTION_NAME)
+     end,
+     fun (_Content) ->
+             Filename = output_filename(?FUNCTION_NAME),
+             maybe_delete(Filename)
+     end,
+     fun (Content) ->
+             [?_assertEqual(<<"stripped_mod:local_fun(5)">>,
+                            get_line_seg(Content, 2, 2)),
+              ?_assertEqual(<<"stripped_mod:local_fun/1">>,
+                            get_line_seg(Content, 3, 4))]
+     end}.
 
-loct_stripped_full_module_count_test() ->
-  M = load_stripped_module(),
-  redbug_start(?FUNCTION_NAME, "stripped_mod->count", []),
-  M:exported_fun(5),
-  redbug_normal_stop(),
-  unload_module(M),
-  Content = redbug_output(?FUNCTION_NAME),
-  ?assertEqual(<<"stripped_mod:local_fun(5)">>,
-               get_line_seg(Content, 4, 2)),
-  ?assertEqual(<<"stripped_mod:local_fun/1">>,
-               get_line_seg(Content, 5, 4)).
+loct_stripped_full_module_count_test_() ->
+    {setup,
+     fun () ->
+             M = load_stripped_module(),
+             redbug_start(?FUNCTION_NAME, "stripped_mod->count", []),
+             M:exported_fun(5),
+             redbug_normal_stop(),
+             unload_module(M),
+             redbug_output(?FUNCTION_NAME)
+     end,
+     fun (_Content) ->
+             Filename = output_filename(?FUNCTION_NAME),
+             maybe_delete(Filename)
+     end,
+     fun (Content) ->
+             [?_assertEqual(<<"stripped_mod:local_fun(5)">>,
+                            get_line_seg(Content, 4, 2)),
+              ?_assertEqual(<<"stripped_mod:local_fun/1">>,
+                            get_line_seg(Content, 5, 4))]
+     end}.
 
 load_stripped_module() ->
   TestCode =
@@ -260,7 +420,6 @@ redbug_output(Name) ->
   Filename = output_filename(Name),
   Content = read_file(Filename),
   maybe_show(Content),
-  maybe_delete(Filename),
   Content.
 
 maybe_show(Content) ->

--- a/test/redbug_eunit.erl
+++ b/test/redbug_eunit.erl
@@ -6,63 +6,63 @@
 -include_lib("eunit/include/eunit.hrl").
 
 millisecond_test_() ->
-  {setup,
-   fun () ->
-           redbug_start(?FUNCTION_NAME, "lists:sort", [print_msec]),
-           [1, 2, 3] = lists:sort([3, 2, 1]),
-           redbug_normal_stop(),
-           redbug_output(?FUNCTION_NAME)
-   end,
-   fun (_Content) ->
-           Filename = output_filename(?FUNCTION_NAME),
-           maybe_delete(Filename)
-   end,
-   fun (Content) ->
-           Timestamp = get_line_seg(Content, 1, 2),
-           [?_assertEqual(<<"lists:sort([3,2,1])">>,
-                          get_line_seg(Content, 2, 2)),
-            ?_assertEqual({match, [{0,12}, {0,0}, {12,0}]},
-                          re:run(Timestamp, "(.*)[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}(.*)", [{capture, all}]))]
-   end}.
+    {setup,
+     fun () ->
+             redbug_start(?FUNCTION_NAME, "lists:sort", [print_msec]),
+             [1, 2, 3] = lists:sort([3, 2, 1]),
+             redbug_normal_stop(),
+             redbug_output(?FUNCTION_NAME)
+     end,
+     fun (_Content) ->
+             Filename = output_filename(?FUNCTION_NAME),
+             maybe_delete(Filename)
+     end,
+     fun (Content) ->
+             Timestamp = get_line_seg(Content, 1, 2),
+             [?_assertEqual(<<"lists:sort([3,2,1])">>,
+                            get_line_seg(Content, 2, 2)),
+              ?_assertEqual({match, [{0,12}, {0,0}, {12,0}]},
+                            re:run(Timestamp, "(.*)[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}(.*)", [{capture, all}]))]
+     end}.
 
 arity_test_() ->
-  {setup,
-   fun () ->
-           redbug_start(?FUNCTION_NAME, "lists:sort", [arity]),
-           [1, 2, 3] = lists:sort([3, 2, 1]),
-           redbug_normal_stop(),
-           redbug_output(?FUNCTION_NAME)
-   end,
-   fun (_Content) ->
-           Filename = output_filename(?FUNCTION_NAME),
-           maybe_delete(Filename)
-   end,
-   fun (Content) ->
-           [?_assertEqual(<<"lists:sort/1">>,
-                          get_line_seg(Content, 2, 2)),
-            ?_assertEqual(3,
-                          length(re:split(get_line_seg(Content, 1, 2), "[:.]")))]
-   end}.
+    {setup,
+     fun () ->
+             redbug_start(?FUNCTION_NAME, "lists:sort", [arity]),
+             [1, 2, 3] = lists:sort([3, 2, 1]),
+             redbug_normal_stop(),
+             redbug_output(?FUNCTION_NAME)
+     end,
+     fun (_Content) ->
+             Filename = output_filename(?FUNCTION_NAME),
+             maybe_delete(Filename)
+     end,
+     fun (Content) ->
+             [?_assertEqual(<<"lists:sort/1">>,
+                            get_line_seg(Content, 2, 2)),
+              ?_assertEqual(3,
+                            length(re:split(get_line_seg(Content, 1, 2), "[:.]")))]
+     end}.
 
 microsecond_test_() ->
-  {setup,
-   fun () ->
-           redbug_start(?FUNCTION_NAME, "lists:sort", [{print_time_unit, microsecond}]),
-           [1, 2, 3] = lists:sort([3, 2, 1]),
-           redbug_normal_stop(),
-           redbug_output(?FUNCTION_NAME)
-   end,
-   fun (_Content) ->
-           Filename = output_filename(?FUNCTION_NAME),
-           maybe_delete(Filename)
-   end,
-   fun (Content) ->
-           Timestamp = get_line_seg(Content, 1, 2),
-           [?_assertEqual(<<"lists:sort([3,2,1])">>,
-                          get_line_seg(Content, 2, 2)),
-            ?_assertEqual({match, [{0,15}, {0,0}, {15,0}]},
-                          re:run(Timestamp, "(.*)[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{6}(.*)", [{capture, all}]))]
-   end}.
+    {setup,
+     fun () ->
+             redbug_start(?FUNCTION_NAME, "lists:sort", [{print_time_unit, microsecond}]),
+             [1, 2, 3] = lists:sort([3, 2, 1]),
+             redbug_normal_stop(),
+             redbug_output(?FUNCTION_NAME)
+     end,
+     fun (_Content) ->
+             Filename = output_filename(?FUNCTION_NAME),
+             maybe_delete(Filename)
+     end,
+     fun (Content) ->
+             Timestamp = get_line_seg(Content, 1, 2),
+             [?_assertEqual(<<"lists:sort([3,2,1])">>,
+                            get_line_seg(Content, 2, 2)),
+              ?_assertEqual({match, [{0,15}, {0,0}, {15,0}]},
+                            re:run(Timestamp, "(.*)[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{6}(.*)", [{capture, all}]))]
+     end}.
 
 buffered_test_() ->
     {setup,
@@ -140,12 +140,12 @@ proc_receive_test_() ->
      end}.
 
 ding_dong_listener()->
-  receive
-      P when is_pid(P) -> P ! ding;
-      quit -> ok
-  after
-      1500 -> timeout
-  end.
+    receive
+        P when is_pid(P) -> P ! ding;
+        quit -> ok
+    after
+        1500 -> timeout
+    end.
 
 call_time_test_() ->
     {setup,
@@ -350,25 +350,25 @@ loct_stripped_full_module_count_test_() ->
      end}.
 
 load_stripped_module() ->
-  TestCode =
+    TestCode =
         "-module(stripped_mod)."
         "-export([exported_fun/1])."
         "exported_fun(X) -> local_fun(X)."
         "local_fun(X) -> X*2.",
-  Opts = [deterministic, no_line_info],
+    Opts = [deterministic, no_line_info],
 
-  {ok, stripped_mod, Bin} = compile_str(TestCode, Opts),
-  {ok, {stripped_mod, StrippedBin}} = beam_lib:strip(Bin),
-  TmpFile = write_beam(stripped_mod, StrippedBin),
+    {ok, stripped_mod, Bin} = compile_str(TestCode, Opts),
+    {ok, {stripped_mod, StrippedBin}} = beam_lib:strip(Bin),
+    TmpFile = write_beam(stripped_mod, StrippedBin),
 
-  %% Verify beam_lib:strip does compressing
-  %% 16#1f8b: gzip magic numbers
-  %% 16#08: Compression method: deflate
-  <<16#1f, 16#8b, 16#08, _/binary>> = StrippedBin,
-  %% verify LocT is actually gone
-  {error, beam_lib, _} = beam_lib:chunks(StrippedBin, [locals]),
-  {module, stripped_mod} = code:load_binary(stripped_mod, TmpFile, StrippedBin),
-  stripped_mod.
+    %% Verify beam_lib:strip does compressing
+    %% 16#1f8b: gzip magic numbers
+    %% 16#08: Compression method: deflate
+    <<16#1f, 16#8b, 16#08, _/binary>> = StrippedBin,
+    %% verify LocT is actually gone
+    {error, beam_lib, _} = beam_lib:chunks(StrippedBin, [locals]),
+    {module, stripped_mod} = code:load_binary(stripped_mod, TmpFile, StrippedBin),
+    stripped_mod.
 
 compile_str(Str, Opts) ->
     Lines = string:split(Str, ".", all),
@@ -395,75 +395,75 @@ beam_filename(Name) ->
     filename(Name, ".beam").
 
 filename(Name, Ext) ->
-  atom_to_list(Name) ++ Ext.
+    atom_to_list(Name) ++ Ext.
 
 redbug_start(TestName, TraceFun, TraceOpts) ->
-  Filename = output_filename(TestName),
-  Options = [{print_file, Filename}, debug|TraceOpts],
-  {ProcessName, NoProcs, NoFuncs} = redbug:start(TraceFun, Options),
-  true = is_process_alive(whereis(ProcessName)),
-  true = (NoProcs + NoFuncs > 0).
+    Filename = output_filename(TestName),
+    Options = [{print_file, Filename}, debug|TraceOpts],
+    {ProcessName, NoProcs, NoFuncs} = redbug:start(TraceFun, Options),
+    true = is_process_alive(whereis(ProcessName)),
+    true = (NoProcs + NoFuncs > 0).
 
 redbug_normal_stop() ->
-  %% collect all traces
-  timer:sleep(100),
-  redbug:stop().
+    %% collect all traces
+    timer:sleep(100),
+    redbug:stop().
 
 write_beam(M, Bin) ->
-  TmpDir = filename:dirname(code:which(redbug_eunit)),
-  TmpFile = filename:join(TmpDir, beam_filename(M)),
-  ok = file:write_file(TmpFile, Bin),
-  {module, M} = code:load_abs(filename:rootname(TmpFile)),
-  TmpFile.
+    TmpDir = filename:dirname(code:which(redbug_eunit)),
+    TmpFile = filename:join(TmpDir, beam_filename(M)),
+    ok = file:write_file(TmpFile, Bin),
+    {module, M} = code:load_abs(filename:rootname(TmpFile)),
+    TmpFile.
 
 unload_module(M) ->
-  TmpDir = filename:dirname(code:which(redbug_eunit)),
-  TmpFile = filename:join(TmpDir, beam_filename(M)),
-  ok = file:delete(TmpFile),
-  code:purge(M).
+    TmpDir = filename:dirname(code:which(redbug_eunit)),
+    TmpFile = filename:join(TmpDir, beam_filename(M)),
+    ok = file:delete(TmpFile),
+    code:purge(M).
 
 redbug_output(Name) ->
-  Filename = output_filename(Name),
-  Content = read_file(Filename),
-  maybe_show(Content),
-  Content.
+    Filename = output_filename(Name),
+    Content = read_file(Filename),
+    maybe_show(Content),
+    Content.
 
 maybe_show(Content) ->
-  [io:fwrite("~p~n", [Content]) || in_shell()].
+    [io:fwrite("~p~n", [Content]) || in_shell()].
 
 lines(Content) ->
-  length(Content).
+    length(Content).
 
 get_line_seg(Content, Line, Seg) ->
-  hd(get_line_seg(Content, Line, Seg, Seg)).
+    hd(get_line_seg(Content, Line, Seg, Seg)).
 
 get_line_seg(Content, Line, SegF, SegL) when Line =< length(Content) ->
-  [e(S, e(Line, Content)) || S <- lists:seq(SegF, SegL)];
+    [e(S, e(Line, Content)) || S <- lists:seq(SegF, SegL)];
 get_line_seg(Content, Line, _SegF, _SegL) ->
-  error({line_out_of_bounds, Line, Content}).
+    error({line_out_of_bounds, Line, Content}).
 
 read_file(Filename) ->
-  {ok, C} = file:read_file(Filename),
-  [[S||S<-re:split(L, "\s"), S=/=<<>>]||L<-re:split(C, "\n"), L=/=<<>>].
+    {ok, C} = file:read_file(Filename),
+    [[S||S<-re:split(L, "\s"), S=/=<<>>]||L<-re:split(C, "\n"), L=/=<<>>].
 
 is_mfa(H) ->
-  L = byte_size(H),
-  {match, [{0, L}]} =:= re:run(H, "[a-zA-Z0-9\'/:_-]*/[0-9]+").
+    L = byte_size(H),
+    {match, [{0, L}]} =:= re:run(H, "[a-zA-Z0-9\'/:_-]*/[0-9]+").
 
 maybe_delete(Filename) ->
-  [file:delete(Filename) || not in_shell()].
+    [file:delete(Filename) || not in_shell()].
 
 in_shell() ->
-  lists:member("shell:eval_loop/3", stack()).
+    lists:member("shell:eval_loop/3", stack()).
 
 stack() ->
-  stack(self()).
+    stack(self()).
 
 stack(P) ->
-  [string:strip(e(2, (string:tokens(L, "(+)")))) || L<- bt(P), $0 =:= hd(L)].
+    [string:strip(e(2, (string:tokens(L, "(+)")))) || L<- bt(P), $0 =:= hd(L)].
 
 bt(P) ->
-  string:tokens(binary_to_list(e(2, (process_info(P, backtrace)))), "\n").
+    string:tokens(binary_to_list(e(2, (process_info(P, backtrace)))), "\n").
 
 e(N, L) when is_list(L) -> lists:nth(N, L);
 e(N, T) when is_tuple(T)-> element(N, T).

--- a/test/redbug_eunit.erl
+++ b/test/redbug_eunit.erl
@@ -400,7 +400,9 @@ filename(Name, Ext) ->
 redbug_start(TestName, TraceFun, TraceOpts) ->
   Filename = output_filename(TestName),
   Options = [{print_file, Filename}, debug|TraceOpts],
-  {_, _, _} = redbug:start(TraceFun, Options).
+  {ProcessName, NoProcs, NoFuncs} = redbug:start(TraceFun, Options),
+  true = is_process_alive(whereis(ProcessName)),
+  true = (NoProcs + NoFuncs > 0).
 
 redbug_normal_stop() ->
   %% collect all traces
@@ -435,8 +437,10 @@ lines(Content) ->
 get_line_seg(Content, Line, Seg) ->
   hd(get_line_seg(Content, Line, Seg, Seg)).
 
-get_line_seg(Content, Line, SegF, SegL) ->
-  [e(S, e(Line, Content)) || S <- lists:seq(SegF, SegL)].
+get_line_seg(Content, Line, SegF, SegL) when Line =< length(Content) ->
+  [e(S, e(Line, Content)) || S <- lists:seq(SegF, SegL)];
+get_line_seg(Content, Line, _SegF, _SegL) ->
+  error({line_out_of_bounds, Line, Content}).
 
 read_file(Filename) ->
   {ok, C} = file:read_file(Filename),

--- a/test/redbug_eunit.erl
+++ b/test/redbug_eunit.erl
@@ -59,7 +59,7 @@ return_stack_test() ->
                lists:usort([is_mfa(get_line_seg(Content, L, 2))||L<-Lines])).
 
 proc_send_test() ->
-  Pid = spawn(fun()->receive P when is_pid(P)->P!ding;quit->ok end end),
+  Pid = spawn(fun()->receive P when is_pid(P)->P!ding; quit->ok; after 1500 -> timeout end end),
   redbug_start(?FUNCTION_NAME, send, [{procs, Pid}]),
   Pid ! self(),
   redbug_normal_stop(),
@@ -68,7 +68,7 @@ proc_send_test() ->
                get_line_seg(Content, 2, 4)).
 
 proc_receive_test() ->
-  Pid = spawn(fun()->receive P when is_pid(P)->P!ding;quit->ok end end),
+  Pid = spawn(fun()->receive P when is_pid(P)->P!ding; quit->ok; after 1500 -> timeout end end),
   redbug_start(?FUNCTION_NAME, 'receive', [{procs, Pid}]),
   Pid ! pling,
   redbug_normal_stop(),
@@ -191,7 +191,7 @@ load_stripped_module() ->
         "-export([exported_fun/1])."
         "exported_fun(X) -> local_fun(X)."
         "local_fun(X) -> X*2.",
-  Opts = [determenistic, no_line_info],
+  Opts = [deterministic, no_line_info],
 
   {ok, stripped_mod, Bin} = compile_str(TestCode, Opts),
   {ok, {stripped_mod, StrippedBin}} = beam_lib:strip(Bin),
@@ -281,7 +281,7 @@ read_file(Filename) ->
 
 is_mfa(H) ->
   L = byte_size(H),
-  {match, [{0, L}]} =:= re:run(H, "[a-zA_Z0-9\'/:_-]*/[0-9]+").
+  {match, [{0, L}]} =:= re:run(H, "[a-zA-Z0-9\'/:_-]*/[0-9]+").
 
 maybe_delete(Filename) ->
   [file:delete(Filename) || not in_shell()].

--- a/test/redbug_eunit.erl
+++ b/test/redbug_eunit.erl
@@ -23,7 +23,7 @@ millisecond_test_() ->
               [?_assertEqual(<<"lists:sort([3,2,1])">>,
                              get_line_seg(Content, 2, 2)),
                ?_assertEqual({match, [{0,12}, {0,0}, {12,0}]},
-                             re:run(Timestamp, "(.*)[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}(.*)", [{capture, all}]))]
+                             re:run(Timestamp, "(.*)[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{3}(.*)", [{capture, all}]))]
       end}}.
 
 arity_test_() ->
@@ -64,7 +64,7 @@ microsecond_test_() ->
               [?_assertEqual(<<"lists:sort([3,2,1])">>,
                              get_line_seg(Content, 2, 2)),
                ?_assertEqual({match, [{0,15}, {0,0}, {15,0}]},
-                             re:run(Timestamp, "(.*)[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{6}(.*)", [{capture, all}]))]
+                             re:run(Timestamp, "(.*)[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{6}(.*)", [{capture, all}]))]
       end}}.
 
 buffered_test_() ->
@@ -104,8 +104,8 @@ return_stack_test_() ->
               Lines = lists:seq(3, lines(Content)-1),
               [?_assertEqual(<<"lists:sort([3,2,1])">>,
                              get_line_seg(Content, 2, 2)),
-               ?_assertEqual([true],
-                             lists:usort([is_mfa(get_line_seg(Content, L, 2))||L<-Lines]))]
+               ?_assertNotEqual([], Lines),
+               ?_assert(lists:all(fun (L) -> is_mfa(get_line_seg(Content, L, 2)) end, Lines))]
       end}}.
 
 proc_send_test_() ->
@@ -376,7 +376,7 @@ load_stripped_module() ->
 
     {ok, stripped_mod, Bin} = compile_str(TestCode, Opts),
     {ok, {stripped_mod, StrippedBin}} = beam_lib:strip(Bin),
-    TmpFile = write_beam(stripped_mod, StrippedBin),
+    write_beam(stripped_mod, StrippedBin),
 
     %% Verify beam_lib:strip does compressing
     %% 16#1f8b: gzip magic numbers
@@ -384,7 +384,6 @@ load_stripped_module() ->
     <<16#1f, 16#8b, 16#08, _/binary>> = StrippedBin,
     %% verify LocT is actually gone
     {error, beam_lib, _} = beam_lib:chunks(StrippedBin, [locals]),
-    {module, stripped_mod} = code:load_binary(stripped_mod, TmpFile, StrippedBin),
     stripped_mod.
 
 compile_str(Str, Opts) ->
@@ -430,13 +429,13 @@ write_beam(M, Bin) ->
     TmpDir = filename:dirname(code:which(redbug_eunit)),
     TmpFile = filename:join(TmpDir, beam_filename(M)),
     ok = file:write_file(TmpFile, Bin),
-    {module, M} = code:load_abs(filename:rootname(TmpFile)),
-    TmpFile.
+    {module, M} = code:load_abs(filename:rootname(TmpFile)).
 
 unload_module(M) ->
     TmpDir = filename:dirname(code:which(redbug_eunit)),
     TmpFile = filename:join(TmpDir, beam_filename(M)),
     ok = file:delete(TmpFile),
+    code:delete(M),
     code:purge(M).
 
 redbug_output(Name) ->
@@ -461,7 +460,7 @@ get_line_seg(Content, Line, _SegF, _SegL) ->
 
 read_file(Filename) ->
     {ok, C} = file:read_file(Filename),
-    [[S||S<-re:split(L, "\s"), S=/=<<>>]||L<-re:split(C, "\n"), L=/=<<>>].
+    [[S||S<-re:split(L, "\\s"), S=/=<<>>]||L<-re:split(C, "\n"), L=/=<<>>].
 
 is_mfa(H) ->
     L = byte_size(H),
@@ -477,7 +476,7 @@ stack() ->
     stack(self()).
 
 stack(P) ->
-    [string:strip(e(2, (string:tokens(L, "(+)")))) || L<- bt(P), $0 =:= hd(L)].
+    [string:trim(e(2, (string:tokens(L, "(+)")))) || L<- bt(P), $0 =:= hd(L)].
 
 bt(P) ->
     string:tokens(binary_to_list(e(2, (process_info(P, backtrace)))), "\n").

--- a/test/redbug_eunit.erl
+++ b/test/redbug_eunit.erl
@@ -399,9 +399,9 @@ redbug_start(TestName, TraceFun, TraceOpts) ->
   {_, _, _} = redbug:start(TraceFun, Options).
 
 redbug_normal_stop() ->
+  %% collect all traces
   timer:sleep(100),
-  redbug:stop(),
-  timer:sleep(100).
+  redbug:stop().
 
 write_beam(M, Bin) ->
   TmpDir = filename:dirname(code:which(redbug_eunit)),


### PR DESCRIPTION
Make redbug:stop syncronized.
Rename test functions from `t_XX_test` to something sensible with more description.
Convert tests from simple tests to test generators with proper setup fixtures.
Add test description and output examples for all tests
Reduce execution time from ~15-16s to 7-8s.
