### PR TITLE
fix: make compile and test correctly with otp 29

### DIFF
--- a/src/redbug.erl
+++ b/src/redbug.erl
@@ -307,16 +307,17 @@ help_text() ->
     , ""].
 
 help_script() ->
-    case catch escript:script_name() of
-        {'EXIT', _} ->
+    try
+        Escript = escript:script_name(),
+        flat("~s ~s~n~s",
+             [Escript,
+              "[-Opt Value [...]] TargetNode Trc [Trc...]",
+              "(you may need to quote trace patterns containing spaces etc)"])
+    catch
+        _:_ ->
             flat("~s~n~s",
                  ["redbug:start(Trc) -> start(Trc, []).",
-                  "redbug:start(Trc, Opts)."]);
-        Escript ->
-            flat("~s ~s~n~s",
-                 [Escript,
-                  "[-Opt Value [...]] TargetNode Trc [Trc...]",
-                  "(you may need to quote trace patterns containing spaces etc)"])
+                  "redbug:start(Trc, Opts)."])
     end.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -339,8 +340,8 @@ dtop(Cfg) ->
     end.
 
 dtop_cfg(Cfg) ->
-    [redbug_dtop:sort(S) || (S = maps:get(sort, Cfg, "")) =/= ""],
-    [redbug_dtop:max_prcs(M) || (M = maps:get(max_procs, Cfg, "")) =/= ""].
+    [redbug_dtop:sort(S) || S <- maps:get(sort, Cfg, ""), S =/= ""],
+    [redbug_dtop:max_prcs(M) || M <- maps:get(max_procs, Cfg, ""), M =/= ""].
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% API from erlang shell
@@ -521,7 +522,8 @@ do_start(OCnf) ->
     Cnf#cnf{trc_pid=redbug_targ:start(Cnf#cnf.target, pack(Cnf))}.
 
 maybe_new_target(Cnf = #cnf{target=Target}) ->
-    case lists:member($@, Str=atom_to_list(Target)) of
+    Str=atom_to_list(Target),
+    case lists:member($@, Str) of
         true -> Cnf;
         false-> Cnf#cnf{target=list_to_atom(Str++"@"++element(2, inet:gethostname()))}
     end.

--- a/src/redbug_compiler.erl
+++ b/src/redbug_compiler.erl
@@ -38,19 +38,26 @@ generate(AST) ->
 
 -spec parse(string()) -> ast().
 parse(Str) ->
-    case catch redbug_parser:parse(scan(Str)) of
-        {ok, AST}              -> AST;
-        {error, {_, _, Error}} -> exit({parse_error, lists:flatten(Error)});
-        {'EXIT', Error}        -> exit(Error)
+    try
+        case redbug_parser:parse(scan(Str)) of
+            {ok, AST}              -> AST;
+            {error, {_, _, Error}} -> exit({parse_error, lists:flatten(Error)})
+        end
+    catch
+        _:R -> exit(R)
     end.
 
 -spec scan(string()) -> tokens().
 scan(Str) ->
-    case catch redbug_lexer:string(Str) of
-        {ok, Tokens, _}                    -> Tokens;
-        {error, {_, _, {illegal, Tok}}, _} -> exit({scan_error, "at: "++Tok});
-        {error, {_, _, Error}, _}          -> exit({scan_error, Error});
-        {'EXIT', R}                        -> exit({scan_error, {bad_input, R}})
+    try
+        case redbug_lexer:string(Str) of
+            {ok, Tokens, _}                    -> Tokens;
+            {error, {_, _, {illegal, Tok}}, _} -> exit({scan_error, "at: "++Tok})
+        end
+    catch
+        _:{scan_error, Error}       -> exit({scan_error, Error});
+        _:{error, {_, _, Error}, _} -> exit({scan_error, Error});
+        _:R                         -> exit({scan_error, {bad_input, R}})
     end.
 
 to_str(Atom) when is_atom(Atom)  -> atom_to_list(Atom);


### PR DESCRIPTION
Replaces old catch syntax with try...catch to make otp 29 happy. Passes `make test`.
