### PR TITLE
fixups after changes for OTP 29

### DIFF
--- a/src/redbug.erl
+++ b/src/redbug.erl
@@ -340,8 +340,8 @@ dtop(Cfg) ->
     end.
 
 dtop_cfg(Cfg) ->
-    [redbug_dtop:sort(S) || S <- maps:get(sort, Cfg, ""), S =/= ""],
-    [redbug_dtop:max_prcs(M) || M <- maps:get(max_procs, Cfg, ""), M =/= ""].
+    [redbug_dtop:sort(S) || S <- [maps:get(sort, Cfg, "")], S =/= ""],
+    [redbug_dtop:max_prcs(M) || M <- [maps:get(max_procs, Cfg, "")], M =/= ""].
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% API from erlang shell

--- a/src/redbug_compiler.erl
+++ b/src/redbug_compiler.erl
@@ -38,26 +38,21 @@ generate(AST) ->
 
 -spec parse(string()) -> ast().
 parse(Str) ->
-    try
-        case redbug_parser:parse(scan(Str)) of
-            {ok, AST}              -> AST;
-            {error, {_, _, Error}} -> exit({parse_error, lists:flatten(Error)})
-        end
+    try redbug_parser:parse(scan(Str)) of
+        {ok, AST}              -> AST;
+        {error, {_, _, Error}} -> exit({parse_error, lists:flatten(Error)})
     catch
-        _:R -> exit(R)
+        _:Error        -> exit(Error)
     end.
 
 -spec scan(string()) -> tokens().
 scan(Str) ->
-    try
-        case redbug_lexer:string(Str) of
-            {ok, Tokens, _}                    -> Tokens;
-            {error, {_, _, {illegal, Tok}}, _} -> exit({scan_error, "at: "++Tok})
-        end
+    try redbug_lexer:string(Str) of
+        {ok, Tokens, _}                    -> Tokens;
+        {error, {_, _, {illegal, Tok}}, _} -> exit({scan_error, "at: "++Tok})
     catch
-        _:{scan_error, Error}       -> exit({scan_error, Error});
-        _:{error, {_, _, Error}, _} -> exit({scan_error, Error});
-        _:R                         -> exit({scan_error, {bad_input, R}})
+        throw:{error, {_, _, Error}, _}          -> exit({scan_error, Error});
+        _:R                     -> exit({scan_error, {bad_input, R}})
     end.
 
 to_str(Atom) when is_atom(Atom)  -> atom_to_list(Atom);


### PR DESCRIPTION
This fixes a couple of things from #49, using the corresponding code from #50. A list comprehension got broken in dtop_cfg, and a nested try/case in redbug_compiler can be simplified.